### PR TITLE
[WIP] Fix broken code

### DIFF
--- a/01_dnn_scratch/12_parameter_search.ipynb
+++ b/01_dnn_scratch/12_parameter_search.ipynb
@@ -458,7 +458,7 @@
         "                                                                  count.item() / num_train_data))\n",
         "\n",
         "    # 探索した結果の保存\n",
-        "    result = {'lr': learning_rate, 'n_hidden': hidden_size,\n",
+        "    result = {'lr': learning_rate, 'n_hidden': n_hidden,\n",
         "              'val_acc': val_accuracy_list,\n",
         "              'train_acc': train_accuracy_list,\n",
         "              'train_loss': train_loss_list}\n",


### PR DESCRIPTION
When running `12_parameter_search.ipynb`, it fails since there is no variable `hidden_size`. It seemed that correct name is `n_hidden`. so I fixed that point.