### PR TITLE
Boston Housingのデータのダウンロードができないバグの修正

### DIFF
--- a/00_no_deep_ml/materials_info.ipynb
+++ b/00_no_deep_ml/materials_info.ipynb
@@ -49,10 +49,10 @@
     "Boston Housing datasetを読み込みます．このデータセットはScikit learnのチュートリアルでも利用されているので，データのダウンロードを行う関数load_boston()も用意されています．\n",
     "\n",
     "**注意**<br>\n",
-    "Boston Housing datasetは黒人の割合などの差別的なデータを含んでいるため，倫理的な観点からScikit learnのversion 1.0以降から非推奨となっています．version 1.2ではこのデータが削除されることが決まっています．<br>\n",
+    "~~Boston Housing datasetは黒人の割合などの差別的なデータを含んでいるため，倫理的な観点からScikit learnのversion 1.0以降から非推奨となっています．version 1.2ではこのデータが削除されることが決まっています．<br>\n",
     "代わりのデータとして，California Housing datasetが用意されています．\n",
     "version 1.2以降でもBoston Housing datasetを使用したい場合はWebから直接ダウンロードしてください．\n",
-    "version 1.0以降のScikit learnでは，この旨を伝える警告文が出力されますがエラーではないです．\n",
+    "version 1.0以降のScikit learnでは，この旨を伝える警告文が出力されますがエラーではないです．~~\n",
     "\n",
     "* Boston Housing datasetの読み込み\n",
     "```python\n",
@@ -69,6 +69,27 @@
     "from sklearn.datasets import fetch_california_housing\n",
     "housing = fetch_california_housing()\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ボストン住宅価格データセットを利用するためにversion 1.1.0のsklearnをインストール\n",
+    "! pip install -U scikit-learn==1.1.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sklearnのバージョン確認\n",
+    "import sklearn\n",
+    "print(sklearn.__version__)"
    ]
   },
   {
@@ -1050,7 +1071,7 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1064,7 +1085,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## 概要
第9回 [マテリアルズインフォマティクス](https://github.com/machine-perception-robotics-group/MPRGDeepLearningLectureNotebook/blob/master/00_no_deep_ml/materials_info.ipynb)

上記のnotebookでBoston Housing datasetがダウンロードできません．
notebook内のコメントに上記の問題点について言及がありますが，本notebookは初学者向けであり個人での解決が困難ことが考えられます．
 
## 変更点

* `該当notebook`の編集
以下の内容を追記．
```python
# ボストン住宅価格データセットを利用するためにversion 1.1.0のsklearnをインストール
! pip install -U scikit-learn==1.1.0

```