### PR TITLE
MNISTデータセットがダウンロードできないバグの修正

### DIFF
--- a/01_dnn_scratch/mlp_mnist.ipynb
+++ b/01_dnn_scratch/mlp_mnist.ipynb
@@ -1,581 +1,679 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VQEJLU_C3_sL"
-      },
-      "source": [
-        "# MLPによる多クラス分類（MNIST）\n",
-        "\n",
-        "---\n",
-        "## 目的\n",
-        "多層パーセプトロン (Multi Layer Perceptoron; MLP) を用いてMNISTデータセットに対する文字認識を行う．\n",
-        "\n",
-        "## モジュールのインポート\n",
-        "プログラムの実行に必要なモジュールをインポートします．"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 49,
-      "metadata": {
-        "id": "7vZoiRR03_sL"
-      },
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt\n",
-        "import gzip"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5VIul2gL3_sO"
-      },
-      "source": [
-        "## データセットのダウンロードと読み込み\n",
-        "\n",
-        "今回の実験では，MNISTデータセットを使用します．\n",
-        "\n",
-        "[MNIST dataset](http://yann.lecun.com/exdb/mnist/)\n",
-        "\n",
-        "まずはじめに，`wget`コマンドを使用して，MNISTデータセットをダウンロードします．"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 50,
-      "metadata": {
-        "id": "8DDcpz6P3_sO"
-      },
-      "outputs": [],
-      "source": [
-        "!wget -q http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz -O train-images-idx3-ubyte.gz\n",
-        "!wget -q http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz -O train-labels-idx1-ubyte.gz\n",
-        "!wget -q http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz -O t10k-images-idx3-ubyte.gz\n",
-        "!wget -q http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz -O t10k-labels-idx1-ubyte.gz"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "6RXTzEns3_sQ"
-      },
-      "source": [
-        "次に，ダウンロードしたファイルからデータを読み込みます．\n",
-        "読み込み方は，[公式HP](http://yann.lecun.com/exdb/mnist/)に公開されているように，`gzip`でファイルを展開し，`frombuffer`関数でnumpy arrayとして読み込みます．\n",
-        "\n",
-        "\n",
-        "ここで読み込んだデータのサイズを確認します．\n",
-        "MNISTデータセットは学習サンプルとして60,000枚，評価サンプルとして10,000枚からなる手書き数字のデータセットです．\n",
-        "MNISTデータセットを読み込んだ段階では，学習および評価データである`x_train`と`x_test`はそれぞれ，`(サンプル数，画素を一列に並べたデータ)`となっています．\n",
-        "MNISTデータセットの画像サイズは28×28なので，784次元のデータとして格納されています．"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 51,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
-        },
-        "id": "qGEMFDLI3_sR",
-        "outputId": "0533962b-b62d-49d7-a8e6-c294c5295ee8"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "(60000, 784) (60000,)\n",
-            "(10000, 784) (10000,)\n"
-          ]
-        }
-      ],
-      "source": [
-        "# load images\n",
-        "with gzip.open('train-images-idx3-ubyte.gz', 'rb') as f:\n",
-        "    x_train = np.frombuffer(f.read(), np.uint8, offset=16)\n",
-        "x_train = x_train.reshape(-1, 784)\n",
-        "\n",
-        "with gzip.open('t10k-images-idx3-ubyte.gz', 'rb') as f:\n",
-        "    x_test = np.frombuffer(f.read(), np.uint8, offset=16)\n",
-        "x_test = x_test.reshape(-1, 784)\n",
-        "\n",
-        "with gzip.open('train-labels-idx1-ubyte.gz', 'rb') as f:\n",
-        "    y_train = np.frombuffer(f.read(), np.uint8, offset=8)\n",
-        "\n",
-        "with gzip.open('t10k-labels-idx1-ubyte.gz', 'rb') as f:\n",
-        "    y_test = np.frombuffer(f.read(), np.uint8, offset=8)\n",
-        "\n",
-        "print(x_train.shape, y_train.shape)\n",
-        "print(x_test.shape, y_test.shape)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8EgJ-2-E3_sS"
-      },
-      "source": [
-        "### MNISTデータセットの表示\n",
-        "MNISTデータセットに含まれる画像を表示してみます．\n",
-        "ここでは，matplotlibを用いて複数の画像を表示させるプログラムを利用します．"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 52,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 114
-        },
-        "id": "COHcvoTG3_sT",
-        "outputId": "11343749-f44e-4aea-f44b-4975912cbaf1"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "<Figure size 432x288 with 0 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxsAAABQCAYAAABxqWj7AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOyd929c6XX+n+m990YOh72or9pK2mbv2km8iRPDyU8JEhhw8kclCBDYMAwnQeJ1HDuOtVntqq3WEiVS7H16732G8/1B33N2SFFaVZIa3g9AGNaK1J3L9973Pec85zmiTqcDAQEBAQEBAQEBAQGBV434oC9AQEBAQEBAQEBAQKA3EYINAQEBAQEBAQEBAYHXghBsCAgICAgICAgICAi8FoRgQ0BAQEBAQEBAQEDgtSAEGwICAgICAgICAgICrwUh2BAQEBAQEBAQEBAQeC1In/YfRSKR4Iv7/+l0OqLn/R7h/n3N894/4d59jbD2Xg5h7b04wr17cYTn9uUQ1t6LI6y9l0NYey/Ok+6dUNkQEBAQEBAQEBAQEHgtCMGGgICAgICAgICAgMBrQQg2BAQEBAQEBAQEBAReC0KwISAgICAgICAgICDwWhCCDQEBAQEBAQEBAQGB14IQbAgICAgICAgICAgIvBaean0r0LuIRHs7u3U6goObgICAwFHhSXsBIOwHAgJHld3vhZd9FwjBxhFBLpdDr9dDoVDA6/XCZDLBZDLB6XSi1WohFAqhUqkgGo0iHo+jXq+jUChge3v7oC9dQEBAQOA14HQ6MTIyAo1Gg/7+fmi1WpTLZdRqNSQSCdy9exelUgm1Wg3NZvOgL1dAQGAfGBwcxPHjxyGTySASidBut/HgwQMsLS298M8Ugo0jglwuh91uh16vx5UrVzA8PIyhoSGcOXMGlUoFt27dQjwex+3bt3Hv3j0Ui0WUy2Uh2BAQEBDoUTweDz788EO43W689957cLvdSCaTSKVSePDgAZLJJMLhMNrtthBsCAgcEcbHx/E3f/M3UKlUAIBGo4F//ud/xvLy8gtXOA5lsCESiSAW791OIhaLodfroVQqIRKJ+O/KZDIAQC6XQz6fh0qlgtlshlQqhVarhUKhQKfTwfb2NlqtFnK5HBqNBgqFAkql0n5+vH1FJpNBJpPBYrFgZGQEJpMJfX19cLlcMJvNUCqVAACr1QqxWIxAIIBGo4FIJIJYLCZsMC+AVCqFUqmETCaDzWaDVqtFJpNBIpFAq9VCs9kU5An/H6lUCqPRCIVCAZ1OB71ez+XbVquFWCyGQqGAZrOJWq12wFcr8KYhFot5nxCJRJDL5VCpVBCLxZBIJACAUqnEe8BReS6lUinvpQ6Hg99TCoUCGo0GzWYTOp0OarUaKpUKxWLxoC/50CCTyXjt0PlDqVTyu8xoND73z2w2m6hUKmg0GkgmkyiVSkdiLdJzSfdPr9dDr9ejXC4jEokI5499RCwWw2w2Q6PRwO12w2KxQCqVolQqcdL5ZdbkoQs2xGIxxGIxFAoFP9DdKBQKnDlzBn6/HxKJBDKZDHK5HBaLBTKZDJ999hlu3rwJv9+PDz/8EDabDZOTk3A6nWi322i320in0/jiiy8QjUZx+/ZtPHjw4AA+6f5gMBhgsVgwMTGBH//4xxxkqNVqvscqlQrHjh1Dq9XC5OQk8vk8bty4gfn5eZTL5YP+CG8cGo0GAwMDsFgs+P73v49jx47h6tWr+PnPf45isYhUKoVGo3HQl3ko0Gq1uHTpEtxuN86dO4dTp07xAbFQKOAnP/kJ7ty5g0QigVAoJFTaBJ4Z2kfEYjHkcjkkEgmcTicGBwchl8uh1WoBAPfv38fs7CwnonodkUgErVYLtVoNv9+Pc+fOwWw2Q6fTAQB0Oh2USiVcLhdcLheazSYKhQIKhcIBX/nBIxKJoNfrodVqIRKJIJFIoFQq0dfXB6PRiCtXruDSpUsQi8XodDrPfDjLZDJYXFxEMpnEf/zHf+D+/fvY3t7u6fddd6Dm8/mg1+tx7tw5nD17FgsLC/inf/onJBKJg77MI4NSqcSlS5cwOjqK06dPY2RkBNVqFffv30cikUClUnmpn79vwcbuZpPu6gUdLijQkEgk0Gg0XK3oRi6Xw+l0wuPxcNZeLpfD4XBAKpVifn4eWq0WZrMZ/f39cDqdGBsbg9frRavVQqPRQCKRwPLyMhqNBpeJeg26p2q1GiaTCQ6HA/39/XC73ZxF6P67Wq0WnU4HCoUCZrMZ6+vrvFE/z0tzP9mrAra9vX3g10rVNKoiDQ8PY35+HkqlErVa7YlVu6MEbdQqlQoOhwNerxdDQ0OYmpritZvNZmG326HRaCCXyw/6kgUOObTHSCQSSCQSSKVSqFQqPhDKZDJYrVa4XC6upInFYgSDQahUKjSbTbTb7QN/f+wHlKhTKpXQarXQaDSQSCTodDp8/xQKBRQKBQdqR5HuqhjdF51OB4PBAJFIxFVsp9MJs9mMwcFBfoc9z76ZTCbRarWg0WhgMpl4Pdbr9Z5dj7R/U0XIYrHwPlAoFCCXyyESiXr28x8WRCIRZDIZVCoV7HY7+vv7YbPZoNFo0G630Wg0UK1WXzpBui/Bhlgs5uChO5q12WxQKpWwWq3Q6/WQSqVc5g4EAtDr9Y/9LIlEApfLBYPBwMEJAJZInT9/HlqtFn19fXjrrbdgMBig0WhQr9dRLBaRzWYRjUaxvr6Ora0t5HK5/bgF+4pUKoXVaoVarcbly5c5c0z3mzaOdruNVqvFB/ROp8O/G4PBAJ/PB+BR1qVSqfA9PizQC4o2RgAIh8NIp9MHel1KpRIejwc2mw2VSgWhUAjZbFZ4aXZhs9ng9/vhdrtx5coVBAIBXm90n2hNCvdN4JughIlCoUAgEEAgEIBGo4HT6YRCoYDFYoFGo4FWq4XRaIRUKoVMJkOn04HRaITD4UAkEsHt27dfOoP3JlCv1wEAqVQKGxsbKJVK8Pv9XN0QeIRGo2F5J51JhoeH4XK5+Cwjl8vhcrmg0WjQ19cHAM/93tJoNBgZGYHD4cBHH30En8+H5eVlTE9Po9Fo9KT0lpIANpsNf/7nf47x8XFYLBZYLBYYjUbo9Xrk83nBnOA1Y7PZcOrUKdhsNrzzzjuYnJxkKWC1WsXW1hY2NzeRz+df6t/Zl2CDNHndWlmdTofBwUFotVoEAgE4HA4ONHQ6Hc6cOQOr1fpMP7/VaiGbzaJWq2F8fBwmkwl2ux3Dw8NQqVRoNBpoNBoolUpIJpNIJBKIRqOIxWI9KROSSCSsHT158iS++93vQqVSwWAwcKBBgUOz2cT29jZn9FQqFeRyOTQaDaxWK2q1GqrVKur1Otrt9gF/sp3QYUImk7EkolAoHHiwIZPJYDabYTKZUK/XkUgkUCwWD1WgdtDo9XoMDg6iv78fJ0+eRCAQ4MxqN722wQq8HsRiMdRqNR/aLly4AJPJxEGH2+2GwWB47PtIqiKTyTA3N4fp6emeDzY6nQ4ajQY6nQ4KhQKi0Sg6nQ7cbvdBX9qhQ6lUsjKAziQnT56E3+/nigdl5ikTD+xMmDwLKpUKHo8HZrN5x9lnYWEBnU4HrVar596F1GtrNpvx9ttv49KlSyiVSiiXy9Dr9dwv1Gw2hWDjNULnRI/HgxMnTmB4eJjfi6QEikQiL93b/FqDDZlMBrVaDa1WizNnzrDUiUo2TqcTSqUSdrsdBoNhR2WDMtXPQq1Ww/LyMnK5HFKpFLLZLLLZLOr1OmQyGZeA8vk8UqkUUqkUgsHgK9GhHQZIdiKXy6FWq2EwGHDq1Cm43W4MDAzw/dwtZWs2mygWi6jVagiHw6jVahgcHMTAwADMZjMuX76MeDyOmZkZhEIhZDIZxGKxQ3NoVqvVXK0xGo3odDpYX18/6MuCVCrlda/RaKDRaFiS9jRP+6MESc3UajU3qx7Ve0PBvVwuh9Vq5cSMVqtlKVC39C6dTiMUCqHVanFlUq1WQ61Wo1KpIJPJoNlsolwu92xvEMmi9Ho9Nzf7/X4YDAaMjo5iaGgIarUaFosFcrkcnU4H1WqVN1Gq4IrFYhiNRvh8PmSzWRgMBjYj6OX+DepPIYlEtVo9dMmkg0YkEsHhcGBqagoOhwOjo6Mwm82w2WxQq9U7ZHuv6v0llUpht9shEomwtrbGVbhms9mzz3I3JEujryf17gq8OmQyGY9CoHdirVZDoVBgN7pgMPjSJhGvNdhQq9VwuVzwer3427/9W5w8eZIDDdJAdvdqdOsju3sKngZlZ27cuIG1tTXU63XU63XWAnY6HS7F1Wo1lMtlVKtVBIPBnnnBkj7ZZDLB7XbD7XbjBz/4AUZHR2G1WmE0Gvfsb6jVakin00gmk7h69SqSyST+7M/+DH6/H36/Hz/60Y9QKpXw3//935ibm8P9+/eRTCYPTbBhMpkwNDQErVYLm82GTqeD+fn5A70mkUgEhUIBo9EIs9nMX92bkwA4QDQYDFAoFM/8vPciWq0WPp8PRqMRb731Fux2O7xeLzweD7RaLVd9ibt37+I3v/kNyuUy8vk8Wq0WfD4f3G43YrEYvvrqKxQKBWxtbfXkAYVclEjScvnyZVitVpw9exY2m42TK6Sx73Q6KBaLyOVyrIMnK3DKKBsMBrRaLXg8HgCP5EW97FJIgWq5XEY2m4VSqezp4OpFEIlEGB4exve+9z3Y7XacOHGC5eDdeymdWV4FMpkMQ0NDCAQCiMVi8Hq9SKVSKBaLPfks74YCDL1eD51OB51OJzihvWZUKhV8Ph+8Xi90Oh0kEglKpRI2NzexurqK+/fvY2lp6aXPyvsmo1Kr1TxUTq1WP/P3Ul8B8HVJkqznuqVAZC26u+S2vb3N2ftGo4FarcYBSS+U5kQiEXQ6HTQaDWw2G3w+H5xOJwcZlBXd62VIAR9FshSI1Wo1SKVSXngGgwFGo/G5fm+vG5LmmUwmLre2Wq0Dbb4miSAFGyRbo4292Wz2ZDn8eaBnlxroqVcLAMv5Go0G91cVCgXU6/WePAhRkEVJAqPRCLfbDbvdDqfTCYfDAaVSyfeInmOLxQKPx4NyuQydTod2uw2PxwOn0wngkQZXIpEgHo8f8Cd8dVATIx323G43TCYTfD4fXC4XLBYLrFYr93B196W1221kMhlkMhnO5pNxhkql4gQYSUipCtnLdNvGd98vgZ3QHkkZ925DGerLaLfbqNVqfBjbLaUi6D5Tc/6TAhQyxpHL5ZBKpZBKpUcmUbV7XR7livfTIAmaRCKBWq2GRCJBpVJBuVx+5n4huVzOEnQ6QwGPEhHUcpBKpV5JczjwmoONRqOBXC4HrVbLQ+Ke9yWezWaRTqfRarW4YuHxeGAymbgUXCgUMDs7i7t37z7mRkR6Ryqft9ttDlB6AblcjosXL+L48ePo6+vD1NQUtFotPB4PNBrNUzPGlFGlwCKTySCbzWJpaQkGgwFerxcSiYQPN8vLy4dqE3a73Th//jw6nQ7S6fSBWzMqlUqo1Wp4vV6cP38eNpsNm5ubCAaDCIfDiMViqFQqPbP2nheJRAKPxwOj0YgzZ87gvffe46AMAIrFIgqFApaXl/HLX/4SiUQC8/PzSCQSqFarPRWkSSQS+P1+OJ1OHDt2DN/+9reh1+vhdDqh0Wj4YEMNeu12mw/GJpMJH3/8MTqdDjeOqlQqKJVKxGIxaDQaJBIJpNPpngg4yHXQ6XTiypUrsNlsGB8fZ7tMqvxQUEaHE9p/CoUC/v3f/x1/+MMfADw60Hg8Hvz93/89J8BI1keJm16vtNFB1mQywePxwG6388wlgUd0Oh0kk0nMz8+jWq3y3kq0Wi0+4M3OziKbzT7155ERAe0Rhyl5dxgQgopnR6/Xc4Lq/PnzsFqt+OKLL3Djxg1Oqj9tvxSJRPB6vejr6+Ozo9VqRbPZRDKZxP379/HJJ58gkUggk8m8kmt+rW9UivgpW16v16FSqR67CU9aZKSzzWazPPRGIpHAZDJBp9NxAFGv15FMJhGNRl/nxzmU0AFuYmICfr8fZ86c4X6X3UFXN5Qp7M4WisViVKtVZDIZiEQibG9vsyxIq9UeOvtRjUYDl8vF/TgHDVlJ6vV6zrZubm6iUChwsE0uMEcRcgyizL3P59sxcLNer6NUKrErUCwW46pkr1mSkokD9VWdOHECWq0WWq2WXZKAR65BNICUghCyVO4eLEZIpVLE43HuA+kFKIun1+sxNDQEr9eLkydPYmBggO2T94JkQrlcDouLi7hz5w7La6kRlX4+/RsymaznM8mUrZfJZPxu12q1j1U3evkePCu1Wg2pVApGoxGNRmOHhJh6e0qlEsLhMKLR6GP3rPud5XA4IJFIOEB+Gt1OfL303ntWhLX3dBQKBRshTU5OwuPxYGNjA3K5nM9t3xRs0DnFZrNxQ36pVEKtVkM8Huc+6Fc1THdfgo1cLoe7d++iUqnA5XLB4/FwRQIAxsbGdjhhtNttFAoFVKtV3Lp1a0e0JhKJ4Pf7YbVaYbVa4fV6sbW11RON3s+DTCaDwWCAwWBAf38/hoaGYLVaH9swCoUC8vk8KpUKD8gZGRmB0+lkSQENmovFYlAqlahWq2wf+TyN+vtNd4/PQSMWizE6OooTJ05gamqKg2rSRJN18FGEZrdoNBpcvnwZ4+PjGB0d5aZo8qQPBoOYnZ3FwsIC65TJBe2w9Am9DBS4GwwGaLVaXLhwAWfOnOEMvVgs5oGPwWAQwWAQ2WwWy8vLqNVqXNkYGxvD22+/zdLJ7ow0uZ/F4/GembhusVjgdrsxPDyMEydOwOVywW6389rZDbnnBYNBXL16FfF4HAsLCygUClAqlT0ThL0MFHRRcoTMCLqRyWSw2+2czCuXy2g2m6hWqwd01ftLp9NBLBbDvXv3EIlEUKlUdtjx072oVCp8MAOeLKPS6XScaKG5JgqFYsc8sXa7jUQigUKhgI2NDUSjUeTz+SNZDT9qErLnwePx4Nvf/jasVismJiZYimuxWDhgeNqeKRKJ0NfXh7fffhs+n49HSSwsLGBjYwMPHjxgt9ZXJWF+7cFGu91GLpfDnTt3EAwGMTg4iJGREVQqFQSDQZ5mujvYyGQyyOfzuH79On7yk59wY59YLOY5GxMTE7hy5Qrryo4S1OBoNpsxMDCAkZGRPYcv5XI5BINBJJNJzMzMAADLNZrNJkqlEgqFAtsB12o1xGIxNJtNvP/+++xOcFgf+MNyXWKxGOPj4/j444/hcDigUqm4XyiTybCW8ihC04jJx/vSpUvs1kW/v+3tbWxubuL69esIhUI916DbPV+IeqouXbqEDz/8kA99lEXNZDJcEk+n01hdXeU+KolEgvfffx8WiwU2m42nPRPdwUYvvBNFIhHMZjPGxsYwOjqKkydPwul0PjXJQAmu5eVl/Nu//Rs76ZVKJej1eiHYAHa4QlIz7u69Q6lUwuFwYHt7G5FIBIVCgQ8yR+VdFo1GkUgkIJfLcffu3R33iPo1Wq0W8vn8N1at5XI5lEolhoaG8NZbb8FsNrPCgGi32wiHw4hEIlhbW0M4HEa1Wj0SwUan0+FnmkyCqFdNYCderxff+c53YLPZ4HA4oFAoWA4pkUiQSqWeumbEYjEGBgZw5coV6PV6GI1GVCoVzM3N4ebNm1hZWUEkEnmlvZL7IkxttVoc9ZNcp1arIRqNQiKRIBqNIh6P84wN0o0lEgm2sKUmW5FIxOXvWCzGGYVe2FifBZqYbrVaMTo6CofDAavVys1CwKODG9lebm5uYm5uDqVSCblcDmKxGJFIBCaTCdlsFrFYDJFIBMlkkg93zWYT+Xwe7Xabg0Gz2Qyj0QitVguxWIx6vX4g2Way+KWNsrtseNBIpVLOVFEZs1wu7xiKeBSRy+X8UtTpdPx7I6keZaKpukaNvL0EDQezWCyYmpqCzWaDzWaDXC7nSi71q8RiMWxsbCCVSvEhptVqcSMfVTTpgEiHHnruE4kEEolEz0j2yG3ObDY/5gTUPSuI7GqDwSBCoRBWVla4qksbL1kJdw83PYpQVZsaQYFHSajuwJWGk8rlcmxtbbFUNZfLHZl3GfWAikQilnF3/zfqA6U1+DSoN5Iquntl7WkGCjXl9kpV91mhdUWNz3tV3AQe0a3seFazB6quU3/p7rEI3bK9V/2M78tvsdFoYHV1FRKJBMvLy9BqtaynpYNIq9VCX18fTp48iUqlgjt37mBxcRFLS0t8sKUbkc1mkc/nkU6nMTc3h3a7fSg0+/uBXq+H1WrF+Pg4fvzjH8Pr9fK8ElowtVoNa2tryGQy+K//+i/89re/5eyyWq3G9evXsby8jNXVVdy7dw+FQgHhcBiVSoUXrNVqRb1eh0QiQV9fH+x2O9bX1+H3+5HNZhGJRA5EpkHXptPpWGt4WNxUKACiYKPVaiEUCuHhw4eIxWJHZoPejcFgwOnTp+F2u+H3+3dYMddqNZYLTU9P4+bNm2g0Gj1zUCY8Hg/Gx8cxODiIH/7wh3A6nTwILJlMYmNjA5FIBD/96U+xuLiIfD7PAX+z2YRUKkVfXx+8Xi9OnDiByclJnt8CgOUcwWAQd+7cQTgcRiqVOuBP/fKIRCK4XC6cPn0aLpfrsSZm6mmhWUGFQgHXr1/H9evXkcvlsLm5ucMpSKVS7UjQHEU6nQ4qlQpqtRo2Nzdx+/ZtuN1umM3mHRPErVYrvvWtb6FYLKLdbkOtVmNpaQnRaPTIHIDpzEFmA0/qyXgWW1Cj0Yjx8XH09/ezHfruNUgJA6rEkYPhUYMCXZLXCuyEkiw0nLPT6bA08mlKFJlMxkk/p9PJc4goOUrOazSW4lWyL8EGNXoDjwKPcrnMmSilUslD+KxWK9vZVqtVbqjd7TBFDx/1GxwFumUYBoMBFosFXq8XPp9vR2Ta7dBFdsDBYBA6nQ5arRbb29uIx+Oo1+vY2trC+vo6qtUqSqXSjpcauf+QxSxlZfR6PZrN5oEd7ul6tFotVCrVoRgI151VIHkCPbxkKXyUpAfdUCWqexjW7in2ZHOby+WQz+d75j51SwGMRiOcTifcbjcH72SHXC6XkUqlEI/HEQ6HEQqF0Gg0dtgNksW1zWaD0WiERqPZ0Rhdr9fZzYscmHpJekHPFAWi3ZWcbDaLarWKeDyOfD6PUCjEfXy7ZylJJJIjY2/7NCgrT5UwuVz+2Hoh57PuPqO9hsMeBah6+CKQhatGo2H3Peo32r0GhT3jEWT8QHu8wCNIwULvQ1IH0Nc3rReynadRBvTzSA5IX6/DkGXff4s0Z6D7i5q/u20cJyYmoNfrkclkMDs72xPD914UcrBQKBSYnJzEqVOnOEOsUCi4JE7l11wuhwcPHiAUCmFzc5M35+XlZUilUqytrUEmk6FYLPJQsKfdXzrQ+3w+vPPOOwiFQtwwuN/IZDLO8LpcLpZUHRRisZhlGUajERaLhaVmJKOioZJHbeOQy+WQy+VwOBw4deoUZ/TIjrrZbCKVSuHWrVvY2Ng4FNPfXyUqlQqnT5+Gw+HA2bNncf78eXbSa7VaWF5eRjQaxeLiIq5du4ZMJoNgMMjPazcymQzHjh3D5cuX4ff7d6z57e1tPHz4ELdv38bKygpSqdQrbew7SGhQ5y9+8QvY7XaEQiFoNBpEo1HkcjmUSiWkUiluYq5Wq4hEIizF252Bl8lkLGU5DNXQgyYSieDTTz/FwMAA3n//fQwMDBz0JfUUUqkU/f39sFgsGBkZ4aGdJpNpT4ODRqOBe/fu4bPPPkM4HO6JZ/hJULKpe5I9ucFRoFupVA61Sc1+QntAf38/Lly4AJ/PB5VKxY570WgUoVDoscQx8LUhhNFoxNmzZ+Hz+RAIBCCXy1Gv1xGPx1kpdP/+feTz+Vdevdz3YIMiMIIyBo1Gg2+QVCqFz+eDWq3Gl19+yRHcUTusETQUkeZiTE5Owul0QqfTQSaTcbBWrVZRKBSQSqWwubmJtbU1bhRqNBov7NhFlQObzYaJiYnHhhvtJySj8nq9MBqNHJkfVLaNMvcqlYp/RzRIkQLpSqVyJKa/7oZ6WAwGAwYGBuD3+3cMwqJs/NLSEhYWFpBMJnvqGVcoFBgaGsLw8DDOnz+Py5cv8+GiXq8jGo1iYWEB9+7dw7Vr13io5l6BP8mojh8/zs4hxPb2Nra2ttgumAYh9gKdTgehUAj5fB4ul4utWhcWFrhpmRy8isXiN1ZzqBn/qFc2CFIVkIWrwKtFLBbDZrPB7/djcHAQY2Nj3Pu4V7DbarWwvr6Oe/fuPWa122tQsEGSoGazyYdiqVQKjUZzJGbePCsSiQT9/f04ffo0RkZGeIApWcTncjl+lnfvIXRfNRoNmzTZ7XbIZDJUKhVkMhnEYjEEg0Fsbm72RmVjN+12G1tbW9wwNTY2Brlczo1BTqcTLpeL520ctQoHZc7JrnZiYgIDAwPQ6/UQiUSoVqtYXFxEKBRiC9tisYi1tTWk0+lXOgxNJpNxU9FBbdRisZin0ZN+u9VqcZVmvw/1KpUKo6OjsNvtnGkQi8UolUo8I6LZbB6ZdUsNaDKZDMPDwxgeHsbU1NRjA6zy+Tw2NjYQCoUQCoUQi8V65rBjMBjg8Xhgs9lw7NgxDA0NwW63s0SCMvJzc3OYnp7GxsYGO87Qs0oJFppGbzabYTKZuE9DJBKhXq8jHA4jn89jZWUFwWCQ+zx6CbIYTafTmJ+fh0KhQCQS4V6NarW6ZxVjL5RKJSwWC0wm05Ht2XgS3Q5f3c5AAs+O0WjkYMLj8UCr1WJkZAQulwtut5v7JnevPephJUOcZ5HEvOlQkFGr1VjybTabhUrGLsRiMRQKBTQaDTweD4aHh3lOS6VS4Z5Q6k+jPo5urFYrBgcH2UK8v78fGo0GlUoF4XAYn376KSKRCPdjvY61d+DBRqvVwuzsLHvJj42NwWq1YmBgAGq1GsPDwxgdHWVpwFFxnQK+jkb1ej0uX77MB5fR0VEAjwK1UqmEL774Ap9//jkymQxCodCOEhq5gL0K5HI5jEYjT+o9CMRiMYxGI+x2O1unkhwnHo/vu7RLp9Ph3Xff5UO1Xq9HtVpFKpVih69uiWCvQ5I/tVqNd955B3/6p38Ks9m8w58eeGQpeePGDYRCIczOziIUCvVMFjt9SgQAACAASURBVM/lcuGDDz6A2+3GRx99hEAgALFYzP0py8vLSCaT+L//+z9cu3YN9Xod1Wp1x+enZ99gMHAWyuPxwGQysayxXC7j9u3bCAaDuHnzJmZmZthuvJeo1+tcuYjFYhCJRDtceuh/n+X50ul08Pv9XCUR+JonKQgOyyyjww5Nph8bG0NfXx8+/PBDWCwW2O123jMpUbC7qkGW87SHHQUXKprDViwWEQwG2QrYZDId9KUdKqhf1mQyYWJiAm+//Ta76RUKBXz22WeYnZ3FysoKisXinoMg/X4/vve978HlcuH8+fNwOByoVqvI5/OYm5vDP/7jPyIcDu9ZFXlln+O1/NTngCYHt9ttdjlqtVrwer2QSCScJVQoFMjlcqhUKtxj8Cxj2d9kKKJVqVQwmUywWq3Q6/WQy+Wo1WpIJBLI5/OIx+NIJpPI5XLI5XLY3t7e4Yj0Kq/nICVLwM5mbKqukKHAXlrFV/nvkmSKNKXk8OVwOGC326HRaCAWi9FqtZDJZJBOp3nj6NU1uhuqPFETGjmH0eZKcklat6S37wVtMq0RtVoNu93OATHN0KCqRjAYRCKR4ARK98GC1jUF9SaTiTXfJL0gjXP3fBwa/NWr64ykd0/aCKkBl5IgT3pHUb8GzQ8CwP1D9Ds6KFtvgcMHNXFTw7JYLOY9YDcikQg+n497Cu12OzeEq9XqHQ3hdCAkEwMyNkgkEmyg06vPcjfdstpnsQ8+SpDLJs2hs1qtMJvNPDCYzEDS6TRSqRQqlcqO+0d7kVwuh8VigdPpZJMWmUyGbDaLTCaDTCbDM3ReJwcebADg4GFxcRE/+9nP4PP54HA4oNVqMTU1BZPJhEwmg/n5eZRKJZ6wub6+jocPH/aU60o3Go0GLpcLPp8P4+PjPJlaJBIhGo3iZz/7GUKhEO7evYu1tTUefAh8vdn2WpZzL0hOEgwGX8sDQ0EfNadTzwjpJi9evAibzQaDwQAASCQS+P3vf49IJMKuOEdh4wAeVb8GBgbgdDoxODgIr9fLTX/tdhuRSATpdBp/+MMfcPXqVQ6QewEyK/B6vbh8+TJsNhtMJhM6nQ6SySSCwSCWl5fx05/+FOFwGIlEYkeAIJFIYDKZoFKp8M477+Dy5cswmUxc5XW5XJDJZEin01hfX0cwGMT//u//Ym1tref6XZ4XtVqN06dPw2azseab6M7Wj46OwufzsblGp9PhzXp1dRWrq6uIRqMv3N/2JtNt2rLXnx9FVCoVtFotTCYTJicnodfr4fP5YLFYHvu7IpGIe9PUajVL9Xb3FZKcstVq4auvvsL9+/eRSqWwsLCAfD6PxcXFnk4cCDwbOp0ORqMRAwMD+Mu//Eu43W5MTExAp9MhGAxiZmYGoVAIMzMzrAzqpruh/Ny5c7h06RK0Wi10Oh22t7exsLCAL7/8EouLi/uiGDoUwQa9zHK5HFZWVti6tdlssk45m81CJBKhWCxCq9Uik8mgWCzyIaYXX4gymQx6vR4GgwEmkwlmsxnAo/tVKpWwtLSE9fV1hEIhZLPZA77ag6PdbqNSqbAv+fPwNIkA/TeJRAKFQgGFQgGLxQKXywW/34/JyUmYTCa43W4YjUY+4FSrVYRCIQSDQRQKhSMR8AFfW70aDAZYrVa2aKWqRrvd5r4isnktlUo90zzf3YTncrlgtVpZqlOpVJBKpRAOh7GwsIBwOPzYQCbqidJqtejr68OpU6dgMBjQ398PuVzO/w5VNekeBoPBnk24fBN07xQKBRwOBwe3VNntptPpwOVyscyPsszUD0jzm4rF4pHMsO7eQ3ttP31eqJJNlrV9fX0wm83cg7HX3/f5fPD5fPxne91DaoxuNpuIxWJYXFxEMpnE7OwsOwsdxfW3G3q2j5qEj/YEGnNAvbo+n48HmzYaDcTjccTjceRyOZZPdUNmOv39/TvmsQGP9uJMJoP19XXE4/F9URYcimCDoME5kUiErd+GhoYwODgIk8mEsbExNBoNDAwMoFqtwuFwoNPpIJ/PIxgM8lyOXtl4nU4n3nvvPXg8HlgsFohEIuTzeeRyOWxtbWFzc/O1ZfOBnRre7gf+sD38dNj4pqnAGo2G+zyARw8jyVPkcjkPRqRyN0lhyNdaLBbDYrFwky41+dEUWbpf9XqdpzgfxODDg0Cv18Nut8PpdOLy5csIBAIIBAJsYkAvxGvXruHhw4dYXl7mQKNXNlaSW5A7Ga3HTqeD1dVV/M///A834On1ei6NGwwG2O12luVpNBpMTk7C7XbvuaYzmQzm5uZ4iN1RMSCgwF8sFrM8zel0YmhoCGazGRcuXIDD4eDfA30P0el0uN+LklSFQgH379/HjRs3sLa2dqSqkAJ7IxaL2YDk1KlTOHv2LEwmE4aGhqDT6R4bfkiIRCKubj+NZrPJM2EWFxdx7949lEolZDIZNBqNnjm/vAx02P6mPb2XIEMQr9cLvV6PEydO4PTp03A6nejv74fBYODklVqthsfjgUwmw9mzZ+F0OtlshYJkrVaL/v5+jI+Pw+12QyKRoF6vIxQKoVAoYHp6Gnfv3kUul9uXhN+hCzZI033t2jUsLi7i448/xvj4ODQaDZxO5w7No8lk4mFOtVqND8a98rA6HA5cuXIFLpeLy7YUWG1tbWFra+u1T9fc7U5y2AINAKyjpeGDT0Kj0cBms3EwIZVKMTw8DKfTydkr0klKJBJMTU1hcnKS/z7Nh2i32yyL6daS09+p1WqcdTgqwYbBYMDw8DB8Ph8uXbrErnI0iC0ajSKVSuGLL77AF198gUqlgnK53DMHu+4gVS6Xs2sb8CgYXV9fx+9+9zvuB9DpdBgfH8fQ0BC8Xi+mpqZYm0vD0+j+AV9nSDudDrLZLObm5hCPx3tueN/T6B6SaDabYTQacezYMXznO9+BxWLB8ePHufpLf3/3/aM/p76hSqWCBw8e4Fe/+hVKpVJPrUmBF0MikXDP1IULF/BXf/VX0Gg0sFgsnGB6WjX8m6BgI5lMsvX1UenReFbIovognS/3k+4KbSAQgNvtxh/90R/h448/3jHRm6qPVD1Xq9U4c+YMfD4fW59LJBJoNBrodDoONqxWKyQSCarVKlZWVhCPxzE9Pb2va+9QBRtEq9VCOp1Gp9PB8vIy7t69C71eD6/XC4VCwU0vRqMRgUAAOp0O8XgcWq2WG8ypTPmmQU09SqWSN1SyAaaGsmQyiWw2u+9NtY1GA6VS6bFGpP2k25ubHhKlUolAIMCVie4DB0GVCsp8UpaUsstULgfA64aCiu3tbW5iJjvbTCaDSCTCGWqdTscPbKvVQrVaZUvOXob0yHa7HVNTU3C5XDAYDDtekNvb26jVatwM2avuXLQRUMNxq9XirJzH48H58+fZT14mk2FsbAxerxc2mw0WiwUKhYKf81arxYdlCqDpvVYqlZBMJpHJZN7Id9zzQFk6uVzOTlJqtZp7pAKBAOx2O3Q6HQcR1OQtk8m4qX6vQ2B3Qz9VjtPp9JEydBB4Mt0yWqqoPcvB95vsg8n4pt1us6V1vV7nxnCBr6fXNxoNlv70MiSZMhqNbE3rcDgeCzSo8tXpdKDT6SAWi9HX1we9Xs9zhkjKS2dmqog0m02USiWsr69jfX0dqVRqX4PcQxls1Ot1rKysQCqVIpVK4fbt2xgYGMAf//Efw263Y2BggLVoNpsNmUwGZrMZkUgEN2/eZJeqQqHwxj28YrEYXq8XbrcbY2NjO8pnnU4H8XgcDx48wPr6+msf3LV70nuxWOSZCAepsyc3HpKOWK1WfO9732PL2Xw+v+f3UbDRnfEkG1GSQjWbTSQSCdZxr6+vo1QqIRwOo1KpYGNjA6lUCqVSCYVCAX6/H8PDw5w5IHe1ZDKJRCLR08GGSCSCVqvl5twf/ehHPCGbegzImjiTySCVSiGXy72Rz+U3sXsabqlUglKpZIek999/H6dPn96hi1cqlTsm5nY6HQ5Su93P6CBdr9d5GODs7OyBzJXZT2iTJSe+4eFh/PVf/zUHtOT+RtIC6vuLRqOIxWIwGo0YGRmBSqXioLgbyia63W6cOnUKW1tbrF8WAg4BYGel4lmqFrur/3utIZVKxeYZ1NybTqexuLjYM8M4XxatVovx8XE22eh1zGYzjh8/DrfbjR/84AcYHx+HWq3eYW6xvb3NrlEqlQoejwfAI1vbVquF06dPY2trCzKZDEajEUqlkvtJKQkTjUbxq1/9Cvfu3dv3Ku6hDDZIigKAM8symQzxeJw3H5VKBalUCpPJBLFYzP0bZDdXKpVQKpXeyEONTCaDRqOBWq3eIacgi9dsNotisfhadNp0+CE/8G6ZULf2/qAO0dvb29wMXi6XUS6X+dBLJVeqUHQjEolgtVphs9kAPApYuj8bZaLJ0YtsSmk6ZzgcRrlcxtbWFk8srtfrMJvNfC/o59HPOQpZZ6VSyTpmh8Px2DwN4OvGcKoK9Wp/AVXb6vU68vk8u1PR7BHSc9Pnp0Pt9vb2Dkvger3OhgTdm02j0UC1WmUJWi9L9LolU3q9Hg6HA263G319fdzLIpPJ+HmloWiNRoMDfZpST7+D3Vlpylrr9XrYbDbexOnZ7uVEwV7snrPRfWimvrWjop+nxEGlUuHkCK25p83A6L6HdB+p34/uIb03u6dkF4vFIyEX2guq5NL7EABbDavV6p6eIE5VM51OB4fDwfa0dE6he0Pvo+5mcL1eD4lEwoqORqPBCSqDwcCVXUrGkISXziadToel30dWRtVNsVjkTbZWq0Gn03Hz5NjYGC5evAiVSoXjx49jaGgIRqMRQ0NDWF5exn/+538+Mct9WKFNlhxVKPNOkyE3Nzdx7949ZDKZV3rYoEU/MTGBkZERnDx5EiqViu1K8/k8bt++jV/96ldIp9MHZldarVbx+eef4+HDh1hdXUUsFtuhp6VD216Uy2UkEgmUSiVsbm5y8FQul5HP59mKtFKpsMMVTXamGR50YHY4HJiamsLAwADPU6jVashms29skPu8SKVSTExM8BdVdnaTTqdx48YNzhz3KtSovbCwgH/5l3+By+XCn/zJnyAQCEAmk0Eul6PZbHJFIhgMIp1OIx6PY3V1FbVajdfZuXPn8NZbb0Gv10Ov10MkErHz3MbGRs8GbN3aZZ/PB51OhytXruCDDz6A2WxGX18fZDIZ5ufn2YUvEomgWq0iEomgXC5z4mBkZAQ2mw0OhwNms3nHoYXmwcjlchw/fhxerxdzc3NIp9OIxWLY2tpCJpPhAPKosFePi0QigcPhQCAQQCwW6/lDcbvdRjqdRrFYxKeffopYLAaLxYKJiQkolUpEo1FeG3s9h933UCaTYWhoiJ3SRkdHeR0KlbNHNJtNhEIhKJVKWK3Wg76cfUMsFsPn88HpdOLkyZP4/ve/D7PZDKfTyXPkWq0WIpEIrl69yknmarWKkZERXLp0CTqdDk6nE2q1mu28yaSEHA4BcGDb19eHf/iHf0AkEsG1a9dw48YN1Ov1fVEbHPpggwYtlctlZDIZKJVK5HI5tjg8e/Ys1Go1vF4vOp0Oe9VLpVL85je/OejLfyGoeZk0ohS1VqtVpNNpbG5uolKpvLLMOW3wUqkUHo8HJ0+eRCAQgFwux/b2NnK5HBKJBNbW1jA9PY1KpXJg5d5Go4GVlRX+//SQDQ0NQa1WP/V7abp4Op3G9PQ0D5bL5XJIJpPPdYhTKBTw+/2sl1QoFCiXy6hUKqjVakfigCKRSODxeDAxMQGPx/PEYIOmZm9sbPTMTI29oCpZJBLBjRs34PV6ce7cOXi9Xs44dds0k8nD6uoqbt++jWq1yqVtrVaL0dFRzqQCQCqVwubmJjKZTM8eVLptgGn68qlTp/DRRx9xVp2kZDMzM4jFYlhaWkKxWMTKygoKhQI7gZF8j/TLu/8dSuiQXalIJEJ/fz/LdylRdRSeZeBxyRCtMbFYDIPBAIfDAYPBcChNQl4l29vbXDWfm5tDJBKB3W5HvV6HWq1m62rKxj8NhUKBixcvYnBwEFKpFENDQ0emOvSstFotZLNZxOPxI+UGJxaLuR1gdHQU586d4xkYFMiSJPvWrVss5aY2gYGBAVgsFjYPUqlUPIetGzoXSyQS2Gw2vPfee6hUKshkMpiZmYFYLN6XBOmhDzaI7obvaDSKarWKsbEx1tbSDe4uR5EXdqFQeKMlB91N0Y1Ggw+0L/tQUslXpVLB7/fDYDDg+PHjOHbsGCwWC887WV9fx9raGkKhEPdKHIYXQiKRwMzMDNRqNYLB4I5ZBE+jVCohGAzy5NZqtbqnT/XTIDcIu90OuVzOLkGbm5v75lt9UFCWhLIqXq+X5Yzd5PN55PN5RCIRZLPZI+OcVK/XkUql0G638etf/xqzs7MsqWo2mygWizyIMpPJIJFIIJ1Os1RDoVDAarXC6XRCq9Xy99E6fRXP/mGD3t9msxl+vx9GoxFnz56F2+3G4OAgJ1xoHS0vL2N2dpaljvV6nd9lo6Oj7PTlcrlgNBq5JyadTiMajQIA99OQ8xDZ52YyGdhsNkSjUSSTyR0Hy+773mg0eqqp90kzNuhQRP0tlMyjCnAvQ1VtsViM2dlZKBQKxGIxZLNZls0+7VmUyWRYXFxEPp+HVqvFxYsX9/Hq3wxIHk4ySIISDzRYsXtocS8gFovhdDoxNjYGh8PBYxu2trZYaRGLxRCNRrGysoJcLod6vY52u4319XV8+eWXsNlsOyzTvynh2mw2uXcylUrxfrIf77A3Ktggl5Hl5WWIxWJMTU2xQws1E1osFhgMBmSzWQwNDUGpVLJE4U2GNKR04HgVbj4k2dLr9Th37hz6+vrwzjvv4MKFC2i1WiiVSsjn8+zHvL6+fqgcloLBICKRCL+UnhUK3nY3wD/PA6fX6zE4OAiHwwGlUolOp4NYLIaZmRmsr6/39KFaLpezNCUQCGBkZISdMYhOp4NEIoGVlRUsLS2x9W2vHMyeBsnvIpEIlpeXd8x82L3eurNY5KpmsVjg9XoxODjI7zU69KTTaZRKpZ4MNsRiMTweDz744AO4XC58+9vfht/v5ypvpVLhael37tzB9evX2cWHXKX0ej0uXbqEH/zgBzCbzRgcHIRSqeR7HAqFcO3aNYhEIt6gR0ZG2FXu+9//PhqNBhYWFtiM4/PPP+fqevf6LRQKqFarPbWm99JvSyQS9PX1wev1YmVlBS6XC3K5nPejXobk2zT/C8BzSetEIhFyuRwPhO314OxF2N7eRrFYRC6X43Ma9VNRYstkMvFcpl5590kkEgQCAVy8eBF6vR7lchmlUgmffvop1tfXMTMzg5mZGe6xoDVHRiKpVIqTKY1GA263+5mCjVAohHg8jkgksq+OVIc+2KAFR77L3Y1qRqPxsQmT3a5C5N7ypj/g1BRNGdGXXRzUsEabs81mg8fjgdvt5gbJQqGAzc1NZLNZ1qgepOXtXpBs5SDobmClQySVJnt9ArFSqYTH4+GAQ6VSsYkBzblptVos+4nH4z01vO+b6A4mnicwp3I32R3SF/28SqWCbDbbc7MgRCIRT/WmRnAyG1AoFPxcZTIZNmjIZDJ80Cc5lMvlglarhdPp5GGdZBdJ769gMMiziZrNJjQaDTf+ymQyqFQqbG9vcx+Yy+VCIBBAvV7nRAtltOPxOGKx2KFJvrwMdODLZrNcXeuGJL0ajQZms5n7Go4C9Py9iPNbt0RZkE89GXqmuveIvayHew06p+ZyOU4kh8NhxGIxZDIZFAqFPd/13fbqdBahczD9PPrv3WekYrGIYDCIRCKBfD4vWN92YzAYYDKZYDKZMDo6ypuJXq/H1NQUlErljkVYKBSQzWYRDAaxsrLCzYNvMo1GA6urq4hEIohGoy+1OGgKtlarxfDwMM6cOQObzYa3334bNpsN2WwW9+/fx8LCAv71X/8VqVQKyWSSp7MflQPj89LpdBCJRDA9Pc2H617F7Xbj7/7u7zAwMIC+vj5YLJYdvUWRSATFYhG///3v8cknnyCfz6NQKBz0ZR96uvsIul1CKIBbXV3Fl19+iXw+/8YnUAjqZTl58iTGx8cxMTGBDz/8EBqNBlqtFvV6HQ8ePMCdO3eQSCTw1VdfIZfLIRgMolKpcLLEarXiu9/9Lvr7+9kyvN1uI5/Po1wu43e/+x3m5uYQDAYxOzsLAOzU4vf74fP5YLPZMDExAa1WC4/Hg0AgAK/Xi7fffntHFYp6s27dutUTVXPgUQZ/enoarVYLo6OjGBkZ2bM3w+l04tKlSwiHw0gmkygWiwdwtW8O1Afpdrvhdrt78sD8snRXeXefbborHN3zJnoBqrROT08jnU6zzX4wGEShUHhqUkkmk0GtVrOU2e12swtnOBzGJ598gmQyyUYHRKPR4N6PWCwmWN9SNoA0uAaDAVarFX19fTAajejr64PZbIbb7d7hMEKbMllDFgqF59biHwZ2v+Rpg+suM74IlGGhadlOp5NnRJDuPpvNIpFIYHNzE9PT00ilUi/7cY4M1WqVsxG9chjcC41Gg6GhIZ5h0N0r071WI5EIVlZWeBCRwPPT7bFeLBaRTqdRrVbfuHfaXtBBQiaTwWazIRAIoL+/Hx6PBwqFgmWzyWQSa2triMVi3AReq9UgEomgUChgNBphs9kwNDSEoaEhOJ1OqFQqtgnO5/PY3NzE3NwcotEogsEgDwOVyWQ8k8ntdkOv18NiscDpdPJ7kiyIga8nuBcKBWxsbPSMLScN0o3FYuzfvxcqlQp2ux21Wo2dbnqJvdy4XhTabw0GAyf4er25/kUhRQoFHN3zSroNc3oJml1GfWEPHz7k6vU39aaIxWIolUr+UqvV3JdWLpexurrKFZJuUxZqxid77/3kUL0pFQoFDwkbHByE0WhEf38/D7br7++HSqXikrtWq+UFSNEx2UdSif1N3pTpYZPL5fD5fFCpVJienn6hF5bBYMDw8DAMBgNOnz4Nv9/PEgGJRIJoNIqtrS22Q4vH4+zeJCDQDXmg06ybbmq1Gubn59lpiWSMb/JzuF9Q1imXy3EDai+j0WgwODgIk8mECxcu4OLFizzAq1Ao4M6dO4jFYpiensb9+/fRarW4yk1aZUqYGAwGTE1NwWQyIZlMYmFhAZlMBnNzc8jlcrh79y62trZ2uK6QVXEikUC5XOZhgDqdDuvr6/B6vbDb7fB6vSyBabfbmJ6extLSEhYXF1GpVA7s/r1KqAqUSqV65jM9K3Sw1el0sNls6HQ6SCaTLBt+kWq+TqdDf38/jEYjvvWtb2FiYgIDAwM9GaC9LGTpTzLJZDLJB2ilUonR0VHkcjksLS2xkUYvQI3epVIJxWIRmUyGpU9Pgio8NpsN4+Pj8Hg8nBAhw4pYLIaFhQUEg8HH5jHRGfkgJOiHLtgwmUzsCuLxeDA+Po6RkREe506ltN2Q3KBer+8INt5U6DOStMLj8cBkMrHN2fOi1+tx7NgxOJ1OfPe738XU1BTkcjlUKhUKhQJu376NWCyGa9eu4de//vUbH6gJvD5oDgI1xnevk1qthuXlZczNzSEcDvdUQ9/rptVqIRqNQiaTIZvNHvTlvHbUajVGR0fhcrlw5swZnD17lvvtisUivvrqKzx8+BDr6+tYXV2FRqPBwMAA9Ho9zp49i5GREbjdbkxOTkImk3GfwdLSEm7evIlwOIwbN25w8LY7eULVtmQyiWQyCQB4+PAhlEolYrEYfD4fRkdH0Wg0OKhuNpv4/PPP8dlnn/E+0wtsb28jn89zL0y3w2OvQ0oKnU4Hv9/PA2xpzsGLnCO0Wi3GxsbgdDrx7rvv4syZM9zjJ7CTZrOJcDgMqVSKcDiMdDoNvV7P/VSBQIDnTvzhD3/omSr59vY2Njc3sbW19cx7JMlsLRYLhoeHOekil8tZUZBIJLC8vIytra3X/AmejwNb+dTUQhNc1Wo1rFYrAoEATCYTD8KxWCws1djdDN5sNrnUTh7N5Oe/vLz8Rtuk7V58NPOCrNKo3NY9hZgaHGlcPU0fVygUPITObDZDq9Wi3W6jXC5zU2AwGEQ0Gt33pqFegnSU5XK550q+AGCz2WC32xEIBHhq6W6oNJzNZntCy76f0IGHJuf2OkqlEn19fejr6+P5DbSmpFIpHA4HyuUyVCoVv7f6+vqg0+lYLmU2m1k+EIlEUKlUsLKygpWVFaRSKXaMetYmbprYm8lkWLpBbofAo2wkVUje9IRWN81mE4lEAgC4ukGDKLvfZTqdDj6fD+12GwaDASqV6huzsYcRiUQCjUYDmUwGq9XKVbKxsTFUq1Ukk0l2fXuWz0YNzGq1Gmq1Gj6fjw+DZBXc3SBODdH0tV9TnA8znU6HHfe2t7fZiCASiWBxcRGxWKxnnrdunvX3LhaLYTabYTKZ+L1ptVohkUhQr9extbWFhYUFzM/PH8q998CCDalUCq1WC5VKhampKfT19WFoaAgXLlyATqdjW0Kaor2XvWmpVGL7rqtXryIcDmNxcRErKyuo1+tvfPMavYDoJaZQKHD69GlUq1XE43HcuXOH50Q0Gg2YzWZ4vV6WSlHjpNVqhUajgcPhgEwmY2eVTCaDUCiEdDqNzz//HJFI5LmibIFH0CFJq9XCbrej2Wz2XLAhEolw/PhxfPTRRzsOh7uhiaerq6s9PXzudUDNymazGTabreczyyaTCe+++y5GR0d5cjD1cWg0Grz11lsYHh7m+6BSqeB0OjmBQplimUyGXC6HmzdvYmtrC9evX8f169d5NsnzSmGoGX9jY4MP3N2QHerz2mUfZiqVCu7evQulUomRkRFcvHiRHbm632VutxtWqxUrKyv43e9+h2w2i1wu98YZQFCgazAYcOnSJUxOTnKwkUwmEQwG+f31rPp5uVyO/v5++P1+DA8P4y/+4i9gs9lgMpnYrQ/4ure0++tNC9ZeB51OB6lUCnNzc3C73bDb7Wi1Wrhx4wY++eSTVzrI+E1EY//I6gAAD49JREFUKpVibGwM4+PjOHnyJN59910olUqWQH766af4+c9/jkwmwwNJDxP7FmzQgax7UIvZbIZGo+FuevpSqVScmScow0AWdNTQFo/HkUgkEA6HEQqFEIlEOEPzprLXAY2qOuQHL5FI4HA42BqyVqvBZrNxWc3j8cBut8Nut8NqtUIul0On0wEAN07mcjnE43GkUimkUimk0+lDGRG/KVCza7cNXS9A1oN6vR4ulwtWq/UxOQBNO+2eoi5soM+HSCSCUqmEVqt95gGVbzI0G4MGF3b/uUQigU6n2xFQUDO4VCrlai716GUyGcRiMX7/U4X2RYOBN7kq/iKQdz/pvmu1Gg8r7YaCL3LyelMbd6n6b7Va4XK5uD/HbrcDAIxGI++X31R1kEql0Ol0UCgUsNvtcLlcbL9sMpnYYICaoFutFr8j6V6/irlZvUCr1WK1Cqk2qJ/hKPf+UZO8Xq+H3W5nwwGZTIZMJoNyuYxMJsPuq4dx792XYIM2FbpZdGB+//33YbVa4ff7YbPZoNPpuCy0u5GKSpvlchkzMzMIhUJcySiVSohGozyLohchK8z+/n7o9XqUSiVMTk6iWq3yJmE0GuFyuXiAkEKhgEqlgkKh4InFtVoNGxsbyGQymJ+fxxdffIFSqYRkMslBiMDz0f0C7KUgA3i0kVosFmg0GgQCAYyNjcFgMPBBhA59kUiEm9Ki0SjPhBF4dmh2kNVqPRIyKnIuKxaLUCqVUKlUfHBVKBSw2Wxot9ucaKnVajxYNB6PI5fLIZ1OY3NzE4VCAUtLS8jlckgmk0f6YPKylEolxGIxNJtNlqkRdE/f9HtrNpvxne98B36/HyMjI/B6vVAqlZBKpVCpVDh9+jQ0Gs0z7YlKpRJ+vx96vR5erxderxdarZaTfCSfKhQKiEajKBQKmJ2dRSqVwo0bN7C0tMTTowV2QoHe7hkcRwkKZmncw9tvvw2HwwGpVIpqtYqZmRlEo1EsLS0hm83uGAB4mNiXYEMsFkMul0Mul8NgMMBms8Hv9+PixYtwuVyw2+0wGAxP/RmtVosb/WZmZrCwsIDNzU3Mzs4emayASCRiN5ZmswmPx8OZgEajwZ7ze2Wams0m8vk8isUiIpEI4vE45ufncefOHeFQ+IrppYBDLBZDq9Wy/bTD4YBKpdoxbI6aS1dWVthNSahsPD8kx9BoNEeisrG9vY16vf7YWqEBclqtdsffbzQaSKVSyOfzWF1dRTwex9bWFh48eMATdWu1mtBz9pLUajXk8/k9DSC65xy8yfdYrVZjfHwco6OjcDqd7IIGPKp6+Hw+AI/W3DeZXKjVakxMTMBsNnNVg+j+vmq1inQ6jWQyiQcPHrA1+JuuxHjdPGkGx1GB3B9pxtzAwAA0Gg3EYjHPtVpfX0cikUClUjm09+m1BBvUDGW32zE0NMTN32q1GmazmfsIyNd897RS0qDVajUkEgnE43Fks1ksLy8jn89jYWEBkUikJ0trnU6HMyAkEaNAojvDRAcTagxvt9vctEuSM/JUpingt27dYulUsVjE1tZWT8+D2G9owE65XO6ZabHkhiaXyzn73L3O6vU66vU6gsEgbt++jUQigWw223PP5X5A0lCZTIZisciy0151Bspms7h69Srm5+fh9/vhdDrZ/pwGRNKk6lQqhWKxiI2NDa5skLwil8uxtFZYcy8H2b7Oz8+jWq1ifHz8SFTZupFKpWy3T/vo05DL5XC5XNwcDjw6INOazGQyKJVKWFpawpdffolcLoeFhQVOngo8jlgsZkkyHbALhQJSqdSRe8bNZjM++OADOJ1OjIyMQKfToV6vY21tDYlEAvfu3cPy8jLC4fBBX+pTeS3BBjXwjYyM4Ic//CFMJhN8Ph90Oh2MRiPrbknbvnsjbTabPIzkzp07uHPnDjcO7dY4HsZy0cuwvb2NTCaDRqMBn8+HYDCIarUKuVy+I9igJkrgcRkPaZkbjQbW1tYwPz+PpaUl/OIXv0AqleIsAWlIBV4ekUjEAyeLxWLPWBzShGdySCKdKMn6qtUqSqUSVlZW8Nvf/ha5XE449L0grVYLsVgM1WqVG/x6Mcgg4vE4fv7zn0OhUGBychJ+vx8mkwkejwcikQilUgn1eh0zMzN48OAB25qTPS5JK2gPENbcy9PpdBAKhXD79m3UajW89957MBqNB31Z+4pKpcLExMQzO0Tt7kcFwG6PtVoNi4uLiEQiuHXrFn75y19yv8ZRlgZ9EzSwUywWo7+/H5OTk9jc3GQHzqOEy+XCD3/4QwQCATidThiNRmxsbGBmZgbBYBBXr17F4uL/a+/OeprowjiA/2dKS2kplGmhbPFFTYiimJgQ442J38av5aXeeeuFxMSoF7IYtqYspRsd2+k+G9Nt3qtz3mJ4RSmVTvv8Em8MF3ByZuYszxLr+wO+rldELHnP7XYjEAjA7XbzUrZscCYnJzE1NQW/38+b9nViA8TiIzVNQyKRQLFYRDqd5qelrNzgdWtfOwUr6Vsul5FIJKCqKtxuNx9Dv99/YRHSecqs6zrvuss6SSaTSciyDE3TKAG8h0RR5CUQB1HnRxXAhTCqZrNJncK71G63YZomj8Vl/R3YLdnIyAg8Hs/AjHG73eYVZgqFArxeL3Rd54sJ0zT5u6xarfL3Yme5UHLz2KaOfUvYPByk91qj0YAsy/D5fPzv8ng88Pl8vEDBVX7ues3eg41GA4Zh8GaR8XicRyqwDQgdyFyO9VNjt5ssX4MdLgwjVnzFsiy0221+68uiVtjhe7/rerMRDAZ5FYfnz58jFAphdnYW4XAYkiThn3/+4afyP9eaZtjHI51OY3NzE4qiYH19HZlMBpVKhX9oBqEr+FVs2+YnH9+/f0elUuEddufn5/HkyRM8ffr00nGUZRlbW1soFovY2NhAPp+HLMvI5/O8agu5eZfdzhHyp5rNJu8NwRYnPp8PwWAQoiheyMmq1WqOfw+yUJNGo4Hj42Ok02m4XC5eJpQt5NghFN1i9B7rdSDLMmZmZiDLMkRR5EUiBkU+n8e7d+8QDoextrZ2oUHk7+ZLsdwWFmrVarXw48cP5HI55HI5bG5uolKpIJ1Oo1gs8kp9g76GuS5BEDA/P4+1tTUEAgG4XC5eor+zB9iwqVar2NragqIovPhPqVTC3t4eP0R2gq43Gx6PBxMTEwiFQrh//z4ikQgWFxcxPT2NsbExTE5O8pAL4L9mNp0PG6vEUC6XcXZ2BlmWcXx8jFQqxetQDxO2+apUKojH45iYmMDs7CyazSYWFhZgmiZPogTAH8BqtcqTv2OxGGRZRqlUorjQHuk81RpknQs8doI3KDkp/YTdTjabTei6Dk3TeLlrADyfQdM0/k51+txjc0vTNMd8NAcdO5lnHYnHx8fh9Xr590YUxQthQE6cg5ZlIZPJoFqtIhKJIBAIwOv1ol6v8xvqnw+Q2Fxlf/P5+TlqtRq/1W02m7wMP2tEV6lU+EKZ/Bor/R0MBuH1egH8d6pvmubQrQOZZrMJRVHg8XhQqVRgmiZ0XUehUODVp5yg682GJEl4+PAhFhcXsbKygpmZGd4Fl8V2t9tt1Go1WJaFQqEARVH4A9tsNnlMo6IoOD09haZpPDF6GHeyTKPRgKZpaDQa+PbtG6LRKA4ODvD+/ftLT9JLpRLP8chkMhQ21UOs+tL5+TlWV1cd+cH9Ha1WizfsymazSCaTGB8fx/T0NG04esS2bSQSCXz8+BF37tzBixcv4Ha7sbq6ClEUcXBwAMuyYBgGarWaYz42xBlYRa9oNIrXr1/z0OfOQi7VahW7u7s8jMNp6vU6D8/78uULjo6OsLS0hFwuh6mpKTx+/BjhcJhHZBiGgbOzM5imyfu45PN5xONx3puk0WhAVVX+L5vN4vz83JHjcxts20alUkEikYDf74ckSfw2iN0cDep39ldY7nI0GsXR0REikQgymQz29vYc1a6gq82GIAiQJAn37t3jHcBZJ9hOrDGLqqqIx+OIxWL8StyyLKyvr2N/fx/1er2vS3f9ba1WC4ZhwDAMfjtxVbgOjd3fUavVkEqlAAx2A7B2uw1VVfmpnSzLkCQJwWCQNhs9wpJ0NzY2YBgGnj17Bp/Ph+XlZd65/fDwENVqdei76pKbx+LDVVXF6enp//6ck781rEoUABQKBbhcLty9exemaWJubo73/QLAc6hSqRTK5TIODw+RzWaRTqexu7sL0zRRq9WuLJFLrlar1XB2dnahAfEw5On+iqZp2NnZAQB8/fqV/7/T5lpXmw3btlEsFhGLxVAsFiEIwqX9MlgJVtM0kc1mkc1m+c0GSw6k0oW/h8anPxiGgUwmg3q9jg8fPiASieDk5ASnp6dIpVKo1+u3/SveCPaMCoKARCKBz58/Y2JiAoeHh7xEq2maODg4oEXvDWJx85IkQVEU2LYNj8eDcDiMxcVFLC8v8/wOdgNM7wZy04ZhTrFFrKqqSCaT0DQNnz59wtHREUZHR+HxePhBqaZpyGQyKJfLUBQFhmHwEs3DMFa9ZNs2stksNjc3MTY2BkmSUK/XkU6n+TgPOyfPMeFXv7wgCFf+Zaz+vsvl4qXKLsMexp/rVrM4ZbZQ6dfBtG37jzOAf2f8hsWfjl+/jx1LZGUliF0uF88vYjHPNzWXb3vusQT4sbEx3uWZxTSzRa5pmlBVtS+fXyfOPVZ17tGjR3j16hUWFhawtLSEUCiEk5MTbG9vI5lM4s2bN4jH42g0Gj0pCenEsesXt/3cOt3fnnus2psoirxxKXv3tdtt3pmZhfS0Wi1+QNpvp+5OnXudfZxY41jDMGBZ1l8dZ3rvXd//jV3XORuswyYhw6TVasE0TQAY+MRWlois6zp0Xb/tX2cosA2rqqrI5XIYGRlBOBzG5OQkv+HQdR1erxcjIyNDWxaSkJvSeRA66O/0fsXCpsjgGYzOY4QQMkBYjHIikcDbt28xNTWFly9f4sGDBwiFQlhZWUEgEMDc3BwKhQLvok0IIYT0G9psEEJIn2EFNMrlMnZ2duD3+zE7O4vR0VF4vV5MT0/Dsixe+Y9OYgkhhPQr2mwQQkifsm0b9XodgiBgf38fpVIJ0WgU29vbKJfLiMViji0/SgghZDh0nSA+LJyacNUvKOHq+mjudWdQ5p7L5YIoihAEgTf1Y+FWvUrMH5Sxuw303HaH5t710dzrDs296+tZgjghhJDeYxVwCCGEECf55c0GIYQQQgghhFzX5U0xCCGEEEIIIaRLtNkghBBCCCGE9ARtNgghhBBCCCE9QZsNQgghhBBCSE/QZoMQQgghhBDSE7TZIIQQQgghhPTEvzkJrUXktUC8AAAAAElFTkSuQmCC",
-            "text/plain": [
-              "<Figure size 1008x100.8 with 10 Axes>"
-            ]
-          },
-          "metadata": {
-            "needs_background": "light",
-            "tags": []
-          },
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "plt.clf()\n",
-        "fig = plt.figure(figsize=(14, 1.4))\n",
-        "for c in range(10):\n",
-        "    ax = fig.add_subplot(1, 10, c + 1)\n",
-        "    ax.imshow(x_train[c].reshape(28, 28), cmap=plt.get_cmap('gray'))\n",
-        "    ax.set_axis_off()\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qlOaqBgd3_sV"
-      },
-      "source": [
-        "## ネットワークモデルの定義\n",
-        "次に，ニューラルネットワーク（多層パーセプトロン）を定義します．\n",
-        "\n",
-        "まずはじめに，ネットワークの定義に必要な関数を定義します．"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 53,
-      "metadata": {
-        "id": "cVfJLTjw3_sV"
-      },
-      "outputs": [],
-      "source": [
-        "def sigmoid(x):\n",
-        "    return 1 / (1 + np.exp(-x))\n",
-        "\n",
-        "def sigmoid_grad(x):\n",
-        "    return (1.0 - sigmoid(x)) * sigmoid(x)\n",
-        "\n",
-        "def relu(x):\n",
-        "    return np.maximum(0, x)\n",
-        "\n",
-        "def relu_grad(x):\n",
-        "    grad = np.zeros(x.shape)\n",
-        "    grad[x > 0] = 1\n",
-        "    return grad\n",
-        "\n",
-        "def softmax(x):\n",
-        "    if x.ndim == 2:\n",
-        "        x = x.T\n",
-        "        # x = x - np.max(x, axis=0)\n",
-        "        y = np.exp(x) / np.sum(np.exp(x), axis=0)\n",
-        "        return y.T \n",
-        "\n",
-        "    # x = x - np.max(x)\n",
-        "    return np.exp(x) / np.sum(np.exp(x))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "PkdkqRjq3_sX"
-      },
-      "source": [
-        "次に，上で定義した関数を用いてネットワークを定義します．\n",
-        "ここでは，入力層，中間層，出力層から構成される多層パーセプトロンとします．\n",
-        "\n",
-        "入力層と中間層，出力層のユニット数は引数として与え，それぞれ`input_size`，`hidden_size`, `output_size`とします．\n",
-        "そして，`__init__`関数を用いて，ネットワークのパラメータを初期化します．\n",
-        "`w1`および`w2`は各層の重みで，`b1`および`b2`はバイアスを表しています．\n",
-        "重みは`randn`関数で，標準正規分布に従った乱数で生成した値を保有する配列を生成します．\n",
-        "バイアスは`zeros`関数を用いて，要素が全て0の配列を生成します．\n",
-        "\n",
-        "そして，`forward`関数で，データを入力して結果を出力するための演算を定義します．\n",
-        "\n",
-        "次に，`backward`関数ではパラメータの更新量を計算します．\n",
-        "まず，ネットワークの出力結果と教師ラベルから，誤差`dy`を算出します．\n",
-        "この時，教師ラベルをone-hotベクトルへ変換し，各ユニットの出力との差を取ることで，`dy`を計算しています．\n",
-        "その後，連鎖律に基づいて，出力層から順番に勾配を計算していきます．\n",
-        "このとき，パラメータの更新量を`self.grads`へ保存しておきます．\n",
-        "\n",
-        "最後に`update_parameters`関数で，更新量をもとにパラメータの更新を行います．"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 54,
-      "metadata": {
-        "id": "xkujL9rz3_sX"
-      },
-      "outputs": [],
-      "source": [
-        "class MLP:\n",
-        "\n",
-        "    def __init__(self, input_size, hidden_size, output_size, act_func='sigmoid', w_std=0.01):\n",
-        "        self.w1 = w_std * np.random.randn(input_size, hidden_size)\n",
-        "        self.b1 = np.zeros(hidden_size)\n",
-        "        self.w2 = w_std * np.random.randn(hidden_size, hidden_size)\n",
-        "        self.b2 = np.zeros(hidden_size)\n",
-        "        self.w3 = w_std * np.random.randn(hidden_size, output_size)\n",
-        "        self.b3 = np.zeros(output_size)\n",
-        "\n",
-        "        # 使用する活性化関数の選択\n",
-        "        if act_func == 'sigmoid':\n",
-        "            self.act = sigmoid\n",
-        "            self.act_grad = sigmoid_grad\n",
-        "        elif act_func == 'relu':\n",
-        "            self.act = relu\n",
-        "            self.act_grad = relu_grad\n",
-        "        else:\n",
-        "            print(\"ERROR\")\n",
-        "\n",
-        "        self.grads = {}\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        self.h1 = np.dot(x, self.w1) + self.b1\n",
-        "        self.h2 = self.act(self.h1)\n",
-        "        self.h3 = np.dot(self.h2, self.w2) + self.b2\n",
-        "        self.h4 = self.act(self.h3)\n",
-        "        self.h5 = np.dot(self.h4, self.w3) + self.b3\n",
-        "        self.y = softmax(self.h5)\n",
-        "        return self.y\n",
-        "\n",
-        "    def backward(self, x, t):\n",
-        "        batch_size = x.shape[0]\n",
-        "        self.grads = {}\n",
-        "        \n",
-        "        t = np.identity(10)[t]\n",
-        "        dy = (self.y - t) / batch_size\n",
-        "\n",
-        "        self.grads['w3'] = np.dot(self.h4.T, dy)\n",
-        "        self.grads['b3'] = np.sum(dy, axis=0)\n",
-        "\n",
-        "        d_h4 = np.dot(dy, self.w3.T)\n",
-        "        d_h3 = self.act_grad(self.h3) * d_h4\n",
-        "        self.grads['w2'] = np.dot(self.h2.T, d_h3)\n",
-        "        self.grads['b2'] = np.sum(d_h3, axis=0)\n",
-        "        \n",
-        "        d_h2 = np.dot(d_h3, self.w2.T)\n",
-        "        d_h1 = self.act_grad(self.h1) * d_h2\n",
-        "        self.grads['w1'] = np.dot(x.T, d_h1)\n",
-        "        self.grads['b1'] = np.sum(d_h1, axis=0)\n",
-        "        \n",
-        "    def update_parameters(self, lr=0.1):\n",
-        "        self.w1 -= lr * self.grads['w1']\n",
-        "        self.b1 -= lr * self.grads['b1']\n",
-        "        self.w2 -= lr * self.grads['w2']\n",
-        "        self.b2 -= lr * self.grads['b2']  \n",
-        "        self.w3 -= lr * self.grads['w3']\n",
-        "        self.b3 -= lr * self.grads['b3']  "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "hZH7MDAX3_sZ"
-      },
-      "source": [
-        "## ネットワークの作成と学習の準備\n",
-        "上のプログラムで定義したネットワークを作成します．\n",
-        "\n",
-        "\n",
-        "まず，中間層と出力層のユニット数を定義します．\n",
-        "ここでは，入力層のユニット数`input_size`を学習データの次元，中間層のユニット数`hidden_size`を64，出力層のユニット数`output_size`を10とします．\n",
-        "\n",
-        "各層のユニット数を`MLPMultinoulli`クラスの引数として与え，ネットワークを作成します．"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 55,
-      "metadata": {
-        "id": "JkW6ljLN3_sa"
-      },
-      "outputs": [],
-      "source": [
-        "input_size = x_train.shape[1]\n",
-        "hidden_size = 64\n",
-        "output_size = 10\n",
-        "model = MLP(input_size=input_size, hidden_size=hidden_size, output_size=output_size, act_func='sigmoid')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HaRjNUOo3_sb"
-      },
-      "source": [
-        "## 学習\n",
-        "読み込んだMNISTデータセットと作成したネットワークを用いて，学習を行います．\n",
-        "\n",
-        "1回の誤差を算出するデータ数（ミニバッチサイズ）を100，学習エポック数を20とします．\n",
-        "\n",
-        "学習データは毎回ランダムに決定するため，numpyの`permutation`という関数を利用します．\n",
-        "各更新において，学習用データと教師データをそれぞれ`x_batch`と`y_batch`とします．\n",
-        "学習モデルに`x_batch`を与えて，`h`を取得します．\n",
-        "取得した`h`は精度および誤差を算出するための関数へと入力され，値を保存します．\n",
-        "そして，誤差を`backward`関数で逆伝播し，`update_parameters`でネットワークの更新を行います．"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 56,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 187
-        },
-        "id": "r108LKmi3_sc",
-        "outputId": "2e6d934c-639b-45ce-cceb-bad8741c6fa7"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "epoch: 1, mean loss: 0.02301107105937889, mean accuracy: 0.11108333333333334\n",
-            "epoch: 2, mean loss: 0.022983986998992595, mean accuracy: 0.11238333333333334\n",
-            "epoch: 3, mean loss: 0.022887905130002172, mean accuracy: 0.11898333333333333\n",
-            "epoch: 4, mean loss: 0.022351524400977905, mean accuracy: 0.22935\n",
-            "epoch: 5, mean loss: 0.020164749245943213, mean accuracy: 0.31521666666666665\n",
-            "epoch: 6, mean loss: 0.017212173979705567, mean accuracy: 0.41025\n",
-            "epoch: 7, mean loss: 0.014904718603752821, mean accuracy: 0.49141666666666667\n",
-            "epoch: 8, mean loss: 0.013105497166232575, mean accuracy: 0.5635\n",
-            "epoch: 9, mean loss: 0.01179012427065201, mean accuracy: 0.6248666666666667\n",
-            "epoch: 10, mean loss: 0.010776288733246311, mean accuracy: 0.6788333333333333\n"
-          ]
-        }
-      ],
-      "source": [
-        "# 学習途中の精度を確認するための関数\n",
-        "def multiclass_classification_accuracy(pred, true):\n",
-        "    clf_res = np.argmax(pred, axis=1)\n",
-        "    return np.sum(clf_res == true).astype(np.float32)\n",
-        "\n",
-        "# 学習中の誤差を確認するための関数\n",
-        "def cross_entropy(y, t):\n",
-        "    if y.ndim == 1:\n",
-        "        t = t.reshape(1, t.size)\n",
-        "        y = y.reshape(1, y.size)\n",
-        "\n",
-        "    # 教師データがone-hot-vectorの場合、正解ラベルのインデックスに変換\n",
-        "    if t.size == y.size:\n",
-        "        t = t.argmax(axis=1)\n",
-        "\n",
-        "    batch_size = y.shape[0]\n",
-        "    return -np.sum(np.log(y[np.arange(batch_size), t] + 1e-7)) / batch_size\n",
-        "\n",
-        "\n",
-        "num_train_data = x_train.shape[0]\n",
-        "num_test_data = x_test.shape[0]\n",
-        "batch_size = 100\n",
-        "epoch_num = 10\n",
-        "learning_rate = 0.01\n",
-        "\n",
-        "epoch_list = []\n",
-        "train_loss_list = []\n",
-        "train_accuracy_list = []\n",
-        "test_accuracy_list = []\n",
-        "\n",
-        "iteration = 0\n",
-        "for epoch in range(1, epoch_num + 1):\n",
-        "    \n",
-        "    sum_accuracy = 0.0\n",
-        "    sum_loss = 0.0\n",
-        "    \n",
-        "    perm = np.random.permutation(num_train_data)\n",
-        "    for i in range(0, num_train_data, batch_size):\n",
-        "        x_batch = x_train[perm[i:i+batch_size]]\n",
-        "        y_batch = y_train[perm[i:i+batch_size]]\n",
-        "        \n",
-        "        y = model.forward(x_batch)\n",
-        "        sum_accuracy += multiclass_classification_accuracy(y, y_batch)\n",
-        "        sum_loss += cross_entropy(y, y_batch)\n",
-        "        \n",
-        "        model.backward(x_batch, y_batch)\n",
-        "        model.update_parameters(lr=learning_rate)\n",
-        "\n",
-        "        iteration += 1\n",
-        "    \n",
-        "    print(\"epoch: {}, mean loss: {}, mean accuracy: {}\".format(epoch,\n",
-        "                                                               sum_loss / num_train_data,\n",
-        "                                                               sum_accuracy / num_train_data))\n",
-        "    \n",
-        "    test_correct_count = 0\n",
-        "    for i in range(num_test_data):\n",
-        "        input = x_test[i:i+1]\n",
-        "        label = y_test[i:i+1]\n",
-        "        y = model.forward(input)\n",
-        "        \n",
-        "        test_correct_count += multiclass_classification_accuracy(y, label)\n",
-        "\n",
-        "    # 学習途中のlossと精度の保存\n",
-        "    epoch_list.append(epoch)\n",
-        "    train_loss_list.append(sum_loss / num_train_data)\n",
-        "    train_accuracy_list.append(sum_accuracy / num_train_data)\n",
-        "    test_accuracy_list.append(test_correct_count / num_test_data)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "H_MuepUh3_sd"
-      },
-      "source": [
-        "## テスト\n",
-        "学習したネットワークを用いて，テストデータに対する認識率の確認を行います．"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 57,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "id": "1U4HfEWD3_se",
-        "outputId": "38992fd9-cf76-4c1d-de0a-888013a3ea5f"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "test accuracy: 0.7001\n"
-          ]
-        }
-      ],
-      "source": [
-        "count = 0\n",
-        "num_test_data = x_test.shape[0]\n",
-        "\n",
-        "for i in range(num_test_data):\n",
-        "    x = np.array([x_test[i]], dtype=np.float32)\n",
-        "    t = y_test[i]\n",
-        "    y = model.forward(x)\n",
-        "    \n",
-        "    pred = np.argmax(y.flatten())\n",
-        "    \n",
-        "    if pred == t:\n",
-        "        count += 1\n",
-        "        \n",
-        "print(\"test accuracy: {}\".format(count / num_test_data))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FIVu8qHOJN8B"
-      },
-      "source": [
-        "## 学習推移のグラフ化"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "zfePKY2xJNae"
-      },
-      "outputs": [],
-      "source": [
-        "plt.figure()\n",
-        "plt.plot(epoch_list, train_loss_list, label='loss (train)')\n",
-        "plt.xlabel(\"epoch\")     # x軸ラベル\n",
-        "plt.ylabel(\"loss\")      # y軸ラベル\n",
-        "plt.legend()            # 凡例\n",
-        "plt.show()\n",
-        "\n",
-        "plt.figure()\n",
-        "plt.plot(epoch_list, train_accuracy_list, label='accuracy (train)')\n",
-        "plt.plot(epoch_list, test_accuracy_list, label='accuracy (test)')\n",
-        "plt.xlabel(\"epoch\")     # x軸ラベル\n",
-        "plt.ylabel(\"accuracy\")  # y軸ラベル\n",
-        "plt.legend()            # 凡例\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XJiDB3Is3_sf"
-      },
-      "source": [
-        "## 課題\n",
-        "1. エポック数を50にして学習推移と認識率の変化について確認しよう\n",
-        "2. 活性化関数をReLUに変更して認識性能の変化について確認しよう\n",
-        "3. 最も高い認識率となるようにパラメータを探索しよう"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [],
-      "name": "04_mlp_mnist.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.5.2"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VQEJLU_C3_sL"
+   },
+   "source": [
+    "# MLPによる多クラス分類（MNIST）\n",
+    "\n",
+    "---\n",
+    "## 目的\n",
+    "多層パーセプトロン (Multi Layer Perceptoron; MLP) を用いてMNISTデータセットに対する文字認識を行う．\n",
+    "\n",
+    "## モジュールのインポート\n",
+    "プログラムの実行に必要なモジュールをインポートします．"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "7vZoiRR03_sL"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import gzip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5VIul2gL3_sO"
+   },
+   "source": [
+    "## データセットのダウンロードと読み込み\n",
+    "\n",
+    "今回の実験では，MNISTデータセットを使用します．\n",
+    "\n",
+    "[MNIST dataset](http://yann.lecun.com/exdb/mnist/)\n",
+    "\n",
+    "今回はtorchvisionのMNISTを利用します．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "8DDcpz6P3_sO"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz\n",
+      "Failed to download (trying next):\n",
+      "HTTP Error 403: Forbidden\n",
+      "\n",
+      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz\n",
+      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz to ./MNIST/raw/train-images-idx3-ubyte.gz\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100.0%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting ./MNIST/raw/train-images-idx3-ubyte.gz to ./MNIST/raw\n",
+      "\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz\n",
+      "Failed to download (trying next):\n",
+      "HTTP Error 403: Forbidden\n",
+      "\n",
+      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz\n",
+      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz to ./MNIST/raw/train-labels-idx1-ubyte.gz\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100.0%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting ./MNIST/raw/train-labels-idx1-ubyte.gz to ./MNIST/raw\n",
+      "\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz\n",
+      "Failed to download (trying next):\n",
+      "HTTP Error 403: Forbidden\n",
+      "\n",
+      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz\n",
+      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz to ./MNIST/raw/t10k-images-idx3-ubyte.gz\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100.0%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting ./MNIST/raw/t10k-images-idx3-ubyte.gz to ./MNIST/raw\n",
+      "\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz\n",
+      "Failed to download (trying next):\n",
+      "HTTP Error 403: Forbidden\n",
+      "\n",
+      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz\n",
+      "Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz to ./MNIST/raw/t10k-labels-idx1-ubyte.gz\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100.0%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting ./MNIST/raw/t10k-labels-idx1-ubyte.gz to ./MNIST/raw\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torchvision\n",
+    "train_data = torchvision.datasets.MNIST(root=\"./\", train=True, download=True)\n",
+    "test_data = torchvision.datasets.MNIST(root=\"./\", train=False, download=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6RXTzEns3_sQ"
+   },
+   "source": [
+    "読み込んだMNISTは，TensorなためNumPyのndarrayに変換します．\n",
+    "\n",
+    "\n",
+    "ここで読み込んだデータのサイズを確認します．\n",
+    "MNISTデータセットは学習サンプルとして60,000枚，評価サンプルとして10,000枚からなる手書き数字のデータセットです．\n",
+    "MNISTデータセットを読み込んだ段階では，学習および評価データである`x_train`と`x_test`はそれぞれ，`(サンプル数，画素を一列に並べたデータ)`となっています．\n",
+    "MNISTデータセットの画像サイズは28×28なので，784次元のデータとして格納されています．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 51
+    },
+    "id": "qGEMFDLI3_sR",
+    "outputId": "0533962b-b62d-49d7-a8e6-c294c5295ee8"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(60000, 784) (60000,)\n",
+      "(10000, 784) (10000,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "train_data = torchvision.datasets.MNIST(root=\"./\", train=True, download=True)\n",
+    "test_data = torchvision.datasets.MNIST(root=\"./\", train=False, download=True)\n",
+    "\n",
+    "x_train = train_data.data.numpy().reshape(-1, 784)\n",
+    "y_train = train_data.targets.numpy()\n",
+    "x_test = test_data.data.numpy().reshape(-1, 784)\n",
+    "y_test = test_data.targets.numpy()  \n",
+    "\n",
+    "print(x_train.shape, y_train.shape)\n",
+    "print(x_test.shape, y_test.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8EgJ-2-E3_sS"
+   },
+   "source": [
+    "### MNISTデータセットの表示\n",
+    "MNISTデータセットに含まれる画像を表示してみます．\n",
+    "ここでは，matplotlibを用いて複数の画像を表示させるプログラムを利用します．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 114
+    },
+    "id": "COHcvoTG3_sT",
+    "outputId": "11343749-f44e-4aea-f44b-4975912cbaf1"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABFAAAABvCAYAAADL5DRXAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAaB0lEQVR4nO3debRN9f/H8c9VupEuQpNyySyhJF1ZKmNJEpF5aCZKRSoqZUyldZFMRYYVVkKKpEwNskhaSyhURKbKLFPd3x+/1dv78/nec/e+955pn/t8/PXa7b3P+dS+Z9p93p93UkZGRoYBAAAAAABASPliPQAAAAAAAIB4xw0UAAAAAAAAD9xAAQAAAAAA8MANFAAAAAAAAA/cQAEAAAAAAPDADRQAAAAAAAAP3EABAAAAAADwwA0UAAAAAAAAD+f6PTApKSmS44AjIyMjLI/DdYuucF03Y7h20cZrLpi4bsHEe2Vw8ZoLJq5bMPFeGVy85oLJz3VjBgoAAAAAAIAHbqAAAAAAAAB44AYKAAAAAACAB26gAAAAAAAAeOAGCgAAAAAAgAduoAAAAAAAAHjgBgoAAAAAAIAHbqAAAAAAAAB44AYKAAAAAACAB26gAAAAAAAAeOAGCgAAAAAAgAduoAAAAAAAAHg4N9YDALzUrFnT2u7Zs6fkzp07S546dark0aNHW+esW7cuQqMDAACJJD093dp+7LHHJG/YsEFys2bNrOO2b98e2YEBACyff/65tZ2UlCS5fv36EXlOZqAAAAAAAAB44AYKAAAAAACAh4Qo4TnnnHOs7cKFC/s6T5eCFCxYUHLFihUlP/roo9Y5r732muR27dpJPnHihHXc8OHDJb/00ku+xoOzatSoIXnJkiXWvpSUFMkZGRmSO3XqJLl58+bWOcWKFQvzCBEtDRo0kDxjxgzJN998s3Xcjz/+GLUx4f8NGDBAsvs+ly/f2fvzt9xyi+QVK1ZEfFxA0Fx44YXWdqFChSTfcccdkkuUKCF55MiR1jknT56M0OjyhtKlS0vu2LGjte/ff/+VXLlyZcmVKlWyjqOEJ/oqVKggOX/+/Na+evXqSR47dqxkfT1zav78+ZLbtm0r+dSpU7l+7LzIvXZ16tSRPHToUMk33XRT1MaE+PXGG29I1n8rxthLOkQKM1AAAAAAAAA8cAMFAAAAAADAAzdQAAAAAAAAPMTdGiilSpWyts877zzJusapbt26kosUKWKd06pVq1yNYefOnZJHjRpl7bv77rslHzlyRPL3339vHUedf/bdcMMNkufMmSPZXdNGr3uir4GuO3XXPLnxxhsl65bGiVarqut93f8Gc+fOjfZwwqJWrVqS16xZE8ORwBhjunbtKrlfv36Ss6op169ZIC/T62zo109aWpp1XNWqVT0f67LLLrO2datdZN/+/fslr1y50trnrquG6Lv66qsl68+h1q1bS9ZrbxljzOWXXy5Zf0aF4zNJ/02MGzdOcu/eva3jDh8+nOvnygvc7/rLli2TvGfPHsmXXnqpdZzeh8Sm1xd95JFHJJ8+fdo6zm1rHAnMQAEAAAAAAPDADRQAAAAAAAAPcVHCo1vWLl261NrntyVxbumpfbo159GjR63jdBvV3bt3Sz5w4IB1HC1VM6fbRV933XXWvunTp0t2pyaHsmXLFskjRoyQPHPmTOu4r776SrK+vsOGDfP1PEGh28WWL1/e2heUEh53Cm6ZMmUkp6amSk5KSoramHCWvgbnn39+DEeSd9SuXdva1i1WdTtvPcXd1adPH8m///67ZF0Oa4z9Prx69ersDxZWa1t3On+HDh0kFyhQQLL7fvbbb79J1qWquoVumzZtrHN0m9bNmzdnc9Q4duyYZNoRxx/9fa1p06YxHMn/6ty5s+S3337b2qe/fyJndNkOJTx5l16OQbe9/vLLL63jZs+eHfGxMAMFAAAAAADAAzdQAAAAAAAAPMRFCc+OHTsk//nnn9a+3Jbw6CnIBw8etPbdeuutknU3lmnTpuXqORHa+PHjJbdr1y7Xj6fLgAoVKiTZ7YKkS1uqVauW6+eNV3oa6apVq2I4kpxzy7cefPBBybq8gCnq0dOwYUPJvXr1yvQY93o0a9ZM8t69eyMzsAR27733Sk5PT7f2FS9eXLIu/Vi+fLl1XIkSJSS/+uqrmT6PWzqiz2nbtq3/AedB+vvJK6+8IllfuwsvvNDXY+lyVGOMadKkiWQ9VVm/zvTfQWbbyB7d0bF69eqxGwgytWTJEsmhSnj27dtnbetyGl0enFXXON3xU5dIInYo2Y5fuvunMcb0799fsv6d99dff2X7sd3fibo73bZt2yTrEuVoYQYKAAAAAACAB26gAAAAAAAAeOAGCgAAAAAAgIe4WANF10X17dvX2qfr6L/77jvJo0aNCvl469evl9yoUSPJukWdMXbLx8cff9z/gJEtNWvWlHzHHXdIzqqmUa9hsmDBAmvfa6+9Jlm349R/H25b6fr16/t63qBzWwAH0aRJk0Luc9cJQGS4rW0nT54sOdS6VO4aG7QB9efcc89+DF9//fWSJ06cKFm3fzfGmJUrV0oeNGiQZLeVX3JysmTd1q9x48Yhx7N27Vo/w4Yx5u6775b8wAMPZPt8XcOtv6sYY7cxLleuXA5Gh+zSr7NSpUr5OqdWrVrWtl6jhvfA8Hrrrbckz5s3L9NjTp8+bW3npMVtSkqK5A0bNki+/PLLQ56jx8N7aPhlZGRIPv/882M4ErgmTJhgbZcvX15ylSpVJLvfT/x47rnnrO1ixYpJ1usjfv/999l+7NwK/q8tAAAAAACACOMGCgAAAAAAgIe4KOHR3Gl5S5culXzkyBHJusXc/fffb52jSzzcsh3thx9+kPzQQw9le6wIrUaNGpJ16zk9NVJPyTPGmEWLFknWravcNnIDBgyQrMs99u/fL9mdzqVb1ukyIt0G2Rhj1q1bZ4JGt2W+5JJLYjiS8Miqdbn+W0LkdOnSxdoONXVZt82dOnVqJIeUsDp27Cg5VPma+3ev2+QePnw45GPr40KV7ezcudPafvfdd0MPFpbWrVt7HvPrr79a22vWrJHcr18/ybpkx1W5cuXsDw7ZpkuCp0yZYu0bOHBgpue4//zgwYOSx4wZE6aRwRhjzpw5Izmr10tu6RbiRYsW9XWOfh89efJk2MeEs3SpqzHGfPPNNzEaCYwx5vjx49Z2bsut9O/H1NRUa5/+LRfrUi5moAAAAAAAAHjgBgoAAAAAAICHuCvhcYWannzo0KGQ5+iVeWfNmiVZT/1BeFWoUMHa1t2UdEnGH3/8IXn37t3WOXrq+NGjRyV//PHH1nHudnYVKFBA8lNPPWXt69ChQ64eOxaaNm0qWf+7BYkuPSpTpkzI43bt2hWN4eRJxYsXl3zfffdZ+/R7p56iPnjw4IiPK9HorjnG2KvM66mvY8eOlazLFo3JumxH69+/v+cxjz32mLWtSyGRNf1dQ5cBf/rpp5K3bt1qnbNv375sP08ilGYGjfs6DVXCg8TQtm1byfp17fc71QsvvBD2MeU1ukTLGPt3nv4dUbZs2aiNCZnT74/XXHONtW/Tpk2S/XbHueCCCyTr0la3A6Eu13r//ff9DTZCmIECAAAAAADggRsoAAAAAAAAHuK+hCcUPZ2yZs2a1j7dtaVhw4aS9bRa5F5ycrJk3fnIGLusRHdP6ty5s+S1a9da58Si/KRUqVJRf85wq1ixYqb/XHeZinf678edrv7TTz9J1n9LyL3SpUtLnjNnjq9zRo8eLXnZsmXhHlJC0tO7dcmOMcacOnVK8uLFiyXraax///13yMfWK9G7nXb0+1tSUpJkXXo1f/78LMeO0HTXlkiWeKSlpUXsseFPvnxn/38j5eDBpEu0n3nmGWtfuXLlJOfPn9/X461fv17y6dOnczc4WOXBxhjzxRdfSG7WrFmURwPXlVdeKVmXubmlVz179pTstyR45MiRknV3O/0Za4wxN910k7/BRgEzUAAAAAAAADxwAwUAAAAAAMADN1AAAAAAAAA8BHYNlGPHjknWtVjGGLNu3TrJEydOlOzW6+s1ON58803JupUkQrv22msl6zVPXHfddZfkFStWRHRMOGvNmjWxHoJJSUmxtm+77TbJHTt2lOyu3aDpdmlujSxyR1+PatWqhTzu888/l5yenh7RMSWKIkWKSO7Ro4dk9/NFr3vSokULX4+t6/VnzJgh2V0PTNMt/0aMGOHreRB+um20bt2YFbdN5H++/vpra3vVqlU5HxiypNc94TtibOg1uzp16iRZr3WYlbp160r2ew11y3h33ZSFCxdKzmqdKiCoqlatKnnu3LmSixcvLlmvi2eM/995ffr0kdy1a9dMjxkyZIivx4oFZqAAAAAAAAB44AYKAAAAAACAh8CW8Gjbtm2ztvVUoMmTJ0vWU/7cbT2VdurUqZJ3794drmEmHN12SrfINMaewhUPZTt5sQXhRRddlKPzqlevLllfVz1N9oorrrDOOe+88yTrVoH6v7sx9jTX1atXSz558qTkc8+135a+/fZb32NH1twSkeHDh2d63Jdffmltd+nSRfKhQ4fCPq5EpF8TerqrS5d0XHzxxZK7desmuXnz5tY5elptoUKFJLvT0vX29OnTJesSWIRHwYIFJVepUkXyiy++aB0XqtzVfa8M9Tml2zrqvxFjjPnnn3/8DRYIAP0+Z4wxH374oWTdoj2SdCvdCRMmROU5kbVixYrFeggJRX/n1qX1xhjz9ttvSw71OyotLc0659lnn5Wsfye6v0l0u2L9W0P/Bh8/frz3v0CMMAMFAAAAAADAAzdQAAAAAAAAPCRECY9LrxS8ZcsWyXoqkTHGNGjQQPLQoUMlp6amSnZXAN61a1fYxhlEzZo1k1yjRg3J7tRxPdUyHoRaQX/9+vUxGE146bIY/e82btw467jnnnvO1+Ppbix6Wt2ZM2ckHz9+3Dpn48aNkt955x3JutOVMXY51969eyXv3LlTcoECBaxzNm/e7GvcyJzuXDBnzhxf5/z888/Wtr5W8OfUqVOS9+/fL7lEiRLWcb/88otkv50hdBmH7hJx2WWXWcf98ccfkhcsWODrsRFa/vz5rW3diU6/tvR1cLtz6Gunu+bojljG2CVBmp5u3bJlS2uf7pCl//6ARKC/j7hl437kpJRbf+e9/fbbrX2LFi3K9hiQe25JK3Knbdu2kidNmmTt099J9Gtm69atkq+//nrrHL2tu7CWLFnSOk5/TurvSPfdd5/vsccSM1AAAAAAAAA8cAMFAAAAAADAAzdQAAAAAAAAPCTkGijahg0bJLdp08bad+edd0rW7Y4ffvhhyeXLl7fOadSoUbiHGCh6fQrdpnPfvn3WcbNmzYramP6TnJwseeDAgSGPW7p0qWTdbiuoevToIXn79u2S69Spk6PH27Fjh+R58+ZJ3rRpk+RvvvkmR4+tPfTQQ5L1uhDu+hvInX79+kn2W/cdqr0x/Dt48KBk3T76o48+so7Trf22bdsmef78+ZKnTJlinfPXX39JnjlzpmR3DRS9DzmjP+fcdUo++OCDTM956aWXJOvPG2OM+eqrryTra+8e57Zw/Y9+rxw2bJi1L9R7t24Tj5zxu35GvXr1JI8ZMyaiY0p0+vu7McbccsstknW71cWLF0s+ceJEjp7r/vvvl9yrV68cPQbCa9myZZL1WjTIvXvvvVey/v17+vRp6zj9PaZ9+/aSDxw4IPn111+3zrn55psl6/VQ3HWL9PoqxYsXl/zbb79J1q95Y+zvSLHGDBQAAAAAAAAP3EABAAAAAADwkPAlPJqeimSMMdOmTZOsWzfpNoF6OqYx9nSi5cuXh3V8QeZOEd69e3dUnleX7QwYMEBy3759reN0m1w93ezo0aMRHF30vfLKK7Eegm+6jbjmt9UuQtMtxhs3buzrHF0y8uOPP4Z7SHna6tWrJbttjHNCfy7p6bJuaQHlcDmj2xXrchz3c0XTLU1Hjx4t2f3eoa//woULJV9zzTXWcboN8YgRIyTr0h7dItIYY2bMmCH5s88+k+x+Lujp19r69esz/eewX1tZtRvXraWrVKkieePGjZEZWB6iS5SHDBkS1sfWZd+U8MQHXZKoue3kU1NTJeu/EYSml6rQ/50HDx5sHafLe0JxXy/jx4+XnJaW5ms8urxHl27FU8mOixkoAAAAAAAAHriBAgAAAAAA4CHhS3iqVasm+Z577rH21apVS7Iu29HcaZcrV64M4+gSx4cffhi159LlCXpKtV5VWpcjGGNMq1atIj4uhMfcuXNjPYTA+/TTTyUXLVo05HG6m1LXrl0jOSSEke6GllVpAV14/DnnnHOs7UGDBknu06eP5GPHjlnHPfPMM5L1f2tdtqO7EBhjd2a59tprJW/ZssU6rnv37pL1lOaUlBTJbqe1Dh06SG7evLnkJUuWmFB0x4MyZcqEPC6vGzdunGQ9/T0rutNc7969wz0khFGTJk1iPQQ4zpw5k+k/d7u56FJ++KN/I+lucvrzwC/dQceY0B3k2rVrZ227Xbb+o5dciGfMQAEAAAAAAPDADRQAAAAAAAAPCVHCU7FiRWu7Z8+ekvWK6Jdeeqmvx/vnn38ku91k3C4HeY2eOqdzixYtrOMef/zxsD3nE088YW0///zzkgsXLixZdyDo3Llz2J4fCJpixYpJzuo9a+zYsZITrSNVIlu8eHGsh5BQdKmFMXbZzvHjxyW7pRu6VO7GG2+U3K1bN8m33367dY4uv3r55Zclu90OQk2lPnz4sORPPvnE2qe39XTp9u3bZ/pYxvzv5ysyt3nz5lgPIWHpriq6a9zSpUut4/7++++wPad+jRpjTHp6etgeG+Ghy0z0669SpUrWcbo8rkePHhEfVyLI7d+7/u3VunVra58uM9VddGbPnp2r54w3zEABAAAAAADwwA0UAAAAAAAAD9xAAQAAAAAA8BCoNVD0Gia6vleveWKMMaVLl872Y69du1bykCFDJEezPW8Q6DaZOrvry4waNUryO++8I/nPP/+UrGvGjTGmU6dOkqtXry75iiuusI7bsWOHZL0WgF7PAcGi19OpUKGCtU+32kVoeg2FfPn83Rv/+uuvIzUcRBAtN8PrhRdeCLlPtzju27evtW/gwIGSy5Ur5+u59DnDhg2TrNdeC4f33nsv04ycGT16tORevXpJLlu2bMhz9Fpw+ny9LkBeVLduXWu7f//+khs1aiTZbaudkxarF110keSmTZtKHjlypHVcwYIFMz1fr7ty4sSJbD8/wkOvN1WyZElr35NPPhnt4eR5eq2Z7t27W/v27dsnuX79+lEbU7QxAwUAAAAAAMADN1AAAAAAAAA8xF0JzyWXXGJtV6lSRfKYMWMku22s/Fi9erW1/eqrr0rW7bLyeqvinNDTnI2xp3e1atVKsm7BWL58eV+P7ZYZLFu2THJWU68RHLoczG/5SV5Xo0YNa7thw4aS9XvYqVOnJL/55pvWOXv37o3M4BBRV111VayHkFD27NljbZcoUUJycnKyZF1a6lq4cKHklStXSp43b5513K+//io53GU7iI4ffvhBclavRb5LZk5/lzfGmKpVq2Z63NNPP21tHzlyJNvPpUuCrrvuOsn6O4dr+fLlkt966y3J+rsnYse9dvo7DiInNTVV8gMPPCDZvR4TJkyQvHPnzsgPLEb4pQIAAAAAAOCBGygAAAAAAAAeYlbCo1fGHj9+vGR3WnpOpirrko/XX39dsu7YYoy9ujb8WbVqleQ1a9ZIrlWrVshzdIcet0RL0x16Zs6cKVmvZI/El5aWZm1PmTIlNgOJc0WKFLG23U5Y/9m1a5fkPn36RHJIiJIvvvhCsi55o2QgZ+rVq2dtt2jRQrKe9q+7Cxhjd5g7cOCAZKaUJzY9Rf3OO++M4UgSm9vdI5zc1/KCBQsk6++cdN6JPykpKdb2XXfdJXnu3LnRHk6esWTJEsm6nGf69OnWcS+++GLUxhRLzEABAAAAAADwwA0UAAAAAAAAD9xAAQAAAAAA8BDRNVBq164tuW/fvta+G264QXLJkiWz/djHjx+XPGrUKGvf0KFDJR87dizbj43QdEuqli1bSn744Yet4wYMGOD5WOnp6da2bhe3devWnA4RAZSUlBTrIQCBsWHDBslbtmyR7K4ZVrZsWcn79++P/MACym2POm3atEwzYIwxGzdulLxp0yZrX+XKlaM9nMDp2rWrtd2rVy/JXbp0ydVjb9u2zdrWvxX02lF6HRtj7PdUxJ82bdpIPnnypLXPfQ0iMiZPnix50KBBkufPnx+L4cQcM1AAAAAAAAA8cAMFAAAAAADAQ1JGRkaGrwNzMMV++PDhkt0SnlD01EhjjPnoo48knzlzRrJuT3zw4MFsjy3e+bwsniiNiK5wXTdjEv/a6Wm8uh3oxIkTrePc8rBICdprzm1bPGvWLMl169aV/Msvv0guV65c5AcWZUG7buGmX0eTJk2y9q1YsUKynibvfs7GAu+VwZXXX3NBFa/XLTk5WbJ+Pxs8eLB1XNGiRSXPmzdPsm6v6pYT7NmzJ0yjjB3eK42ZOXOmZLdMrnnz5pK3b98etTH5Ea+vOWTNz3VjBgoAAAAAAIAHbqAAAAAAAAB4iGgJD3KOaV/BxFTL4OI1F0x5/bqlpKRInj17trWvYcOGkj/44APJ3bp1kxyrTnW8VwZXXn/NBRXXLZh4rwwuXnPBRAkPAAAAAABAGHADBQAAAAAAwAMlPHGKaV/BxFTL4OI1F0xct7N0OY8xxgwZMkRy9+7dJVerVk1yrDry8F4ZXLzmgonrFky8VwYXr7lgooQHAAAAAAAgDLiBAgAAAAAA4IEbKAAAAAAAAB5YAyVOUTcXTNSqBhevuWDiugUT75XBxWsumLhuwcR7ZXDxmgsm1kABAAAAAAAIA26gAAAAAAAAePBdwgMAAAAAAJBXMQMFAAAAAADAAzdQAAAAAAAAPHADBQAAAAAAwAM3UAAAAAAAADxwAwUAAAAAAMADN1AAAAAAAAA8cAMFAAAAAADAAzdQAAAAAAAAPHADBQAAAAAAwMP/AZoM/G+n9BlGAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1400x140 with 10 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.clf()\n",
+    "fig = plt.figure(figsize=(14, 1.4))\n",
+    "for c in range(10):\n",
+    "    ax = fig.add_subplot(1, 10, c + 1)\n",
+    "    ax.imshow(x_train[c].reshape(28, 28), cmap=plt.get_cmap('gray'))\n",
+    "    ax.set_axis_off()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qlOaqBgd3_sV"
+   },
+   "source": [
+    "## ネットワークモデルの定義\n",
+    "次に，ニューラルネットワーク（多層パーセプトロン）を定義します．\n",
+    "\n",
+    "まずはじめに，ネットワークの定義に必要な関数を定義します．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "cVfJLTjw3_sV"
+   },
+   "outputs": [],
+   "source": [
+    "def sigmoid(x):\n",
+    "    return 1 / (1 + np.exp(-x))\n",
+    "\n",
+    "def sigmoid_grad(x):\n",
+    "    return (1.0 - sigmoid(x)) * sigmoid(x)\n",
+    "\n",
+    "def relu(x):\n",
+    "    return np.maximum(0, x)\n",
+    "\n",
+    "def relu_grad(x):\n",
+    "    grad = np.zeros(x.shape)\n",
+    "    grad[x > 0] = 1\n",
+    "    return grad\n",
+    "\n",
+    "def softmax(x):\n",
+    "    if x.ndim == 2:\n",
+    "        x = x.T\n",
+    "        # x = x - np.max(x, axis=0)\n",
+    "        y = np.exp(x) / np.sum(np.exp(x), axis=0)\n",
+    "        return y.T \n",
+    "\n",
+    "    # x = x - np.max(x)\n",
+    "    return np.exp(x) / np.sum(np.exp(x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "PkdkqRjq3_sX"
+   },
+   "source": [
+    "次に，上で定義した関数を用いてネットワークを定義します．\n",
+    "ここでは，入力層，中間層，出力層から構成される多層パーセプトロンとします．\n",
+    "\n",
+    "入力層と中間層，出力層のユニット数は引数として与え，それぞれ`input_size`，`hidden_size`, `output_size`とします．\n",
+    "そして，`__init__`関数を用いて，ネットワークのパラメータを初期化します．\n",
+    "`w1`および`w2`は各層の重みで，`b1`および`b2`はバイアスを表しています．\n",
+    "重みは`randn`関数で，標準正規分布に従った乱数で生成した値を保有する配列を生成します．\n",
+    "バイアスは`zeros`関数を用いて，要素が全て0の配列を生成します．\n",
+    "\n",
+    "そして，`forward`関数で，データを入力して結果を出力するための演算を定義します．\n",
+    "\n",
+    "次に，`backward`関数ではパラメータの更新量を計算します．\n",
+    "まず，ネットワークの出力結果と教師ラベルから，誤差`dy`を算出します．\n",
+    "この時，教師ラベルをone-hotベクトルへ変換し，各ユニットの出力との差を取ることで，`dy`を計算しています．\n",
+    "その後，連鎖律に基づいて，出力層から順番に勾配を計算していきます．\n",
+    "このとき，パラメータの更新量を`self.grads`へ保存しておきます．\n",
+    "\n",
+    "最後に`update_parameters`関数で，更新量をもとにパラメータの更新を行います．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "xkujL9rz3_sX"
+   },
+   "outputs": [],
+   "source": [
+    "class MLP:\n",
+    "\n",
+    "    def __init__(self, input_size, hidden_size, output_size, act_func='sigmoid', w_std=0.01):\n",
+    "        self.w1 = w_std * np.random.randn(input_size, hidden_size)\n",
+    "        self.b1 = np.zeros(hidden_size)\n",
+    "        self.w2 = w_std * np.random.randn(hidden_size, hidden_size)\n",
+    "        self.b2 = np.zeros(hidden_size)\n",
+    "        self.w3 = w_std * np.random.randn(hidden_size, output_size)\n",
+    "        self.b3 = np.zeros(output_size)\n",
+    "\n",
+    "        # 使用する活性化関数の選択\n",
+    "        if act_func == 'sigmoid':\n",
+    "            self.act = sigmoid\n",
+    "            self.act_grad = sigmoid_grad\n",
+    "        elif act_func == 'relu':\n",
+    "            self.act = relu\n",
+    "            self.act_grad = relu_grad\n",
+    "        else:\n",
+    "            print(\"ERROR\")\n",
+    "\n",
+    "        self.grads = {}\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        self.h1 = np.dot(x, self.w1) + self.b1\n",
+    "        self.h2 = self.act(self.h1)\n",
+    "        self.h3 = np.dot(self.h2, self.w2) + self.b2\n",
+    "        self.h4 = self.act(self.h3)\n",
+    "        self.h5 = np.dot(self.h4, self.w3) + self.b3\n",
+    "        self.y = softmax(self.h5)\n",
+    "        return self.y\n",
+    "\n",
+    "    def backward(self, x, t):\n",
+    "        batch_size = x.shape[0]\n",
+    "        self.grads = {}\n",
+    "        \n",
+    "        t = np.identity(10)[t]\n",
+    "        dy = (self.y - t) / batch_size\n",
+    "\n",
+    "        self.grads['w3'] = np.dot(self.h4.T, dy)\n",
+    "        self.grads['b3'] = np.sum(dy, axis=0)\n",
+    "\n",
+    "        d_h4 = np.dot(dy, self.w3.T)\n",
+    "        d_h3 = self.act_grad(self.h3) * d_h4\n",
+    "        self.grads['w2'] = np.dot(self.h2.T, d_h3)\n",
+    "        self.grads['b2'] = np.sum(d_h3, axis=0)\n",
+    "        \n",
+    "        d_h2 = np.dot(d_h3, self.w2.T)\n",
+    "        d_h1 = self.act_grad(self.h1) * d_h2\n",
+    "        self.grads['w1'] = np.dot(x.T, d_h1)\n",
+    "        self.grads['b1'] = np.sum(d_h1, axis=0)\n",
+    "        \n",
+    "    def update_parameters(self, lr=0.1):\n",
+    "        self.w1 -= lr * self.grads['w1']\n",
+    "        self.b1 -= lr * self.grads['b1']\n",
+    "        self.w2 -= lr * self.grads['w2']\n",
+    "        self.b2 -= lr * self.grads['b2']  \n",
+    "        self.w3 -= lr * self.grads['w3']\n",
+    "        self.b3 -= lr * self.grads['b3']  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hZH7MDAX3_sZ"
+   },
+   "source": [
+    "## ネットワークの作成と学習の準備\n",
+    "上のプログラムで定義したネットワークを作成します．\n",
+    "\n",
+    "\n",
+    "まず，中間層と出力層のユニット数を定義します．\n",
+    "ここでは，入力層のユニット数`input_size`を学習データの次元，中間層のユニット数`hidden_size`を64，出力層のユニット数`output_size`を10とします．\n",
+    "\n",
+    "各層のユニット数を`MLPMultinoulli`クラスの引数として与え，ネットワークを作成します．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "JkW6ljLN3_sa"
+   },
+   "outputs": [],
+   "source": [
+    "input_size = x_train.shape[1]\n",
+    "hidden_size = 64\n",
+    "output_size = 10\n",
+    "model = MLP(input_size=input_size, hidden_size=hidden_size, output_size=output_size, act_func='sigmoid')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HaRjNUOo3_sb"
+   },
+   "source": [
+    "## 学習\n",
+    "読み込んだMNISTデータセットと作成したネットワークを用いて，学習を行います．\n",
+    "\n",
+    "1回の誤差を算出するデータ数（ミニバッチサイズ）を100，学習エポック数を20とします．\n",
+    "\n",
+    "学習データは毎回ランダムに決定するため，numpyの`permutation`という関数を利用します．\n",
+    "各更新において，学習用データと教師データをそれぞれ`x_batch`と`y_batch`とします．\n",
+    "学習モデルに`x_batch`を与えて，`h`を取得します．\n",
+    "取得した`h`は精度および誤差を算出するための関数へと入力され，値を保存します．\n",
+    "そして，誤差を`backward`関数で逆伝播し，`update_parameters`でネットワークの更新を行います．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 187
+    },
+    "id": "r108LKmi3_sc",
+    "outputId": "2e6d934c-639b-45ce-cceb-bad8741c6fa7"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch: 1, mean loss: 0.023008865120750024, mean accuracy: 0.11233333333333333\n",
+      "epoch: 2, mean loss: 0.022985175874084388, mean accuracy: 0.1158\n",
+      "epoch: 3, mean loss: 0.022901067940422067, mean accuracy: 0.12416666666666666\n",
+      "epoch: 4, mean loss: 0.022426513374958216, mean accuracy: 0.18251666666666666\n",
+      "epoch: 5, mean loss: 0.020524579011201593, mean accuracy: 0.2389\n",
+      "epoch: 6, mean loss: 0.01823306931313132, mean accuracy: 0.3037\n",
+      "epoch: 7, mean loss: 0.01668463429252106, mean accuracy: 0.3565\n",
+      "epoch: 8, mean loss: 0.015256962333708952, mean accuracy: 0.47491666666666665\n",
+      "epoch: 9, mean loss: 0.013774003060544725, mean accuracy: 0.5274666666666666\n",
+      "epoch: 10, mean loss: 0.012411224943238515, mean accuracy: 0.6089333333333333\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 学習途中の精度を確認するための関数\n",
+    "def multiclass_classification_accuracy(pred, true):\n",
+    "    clf_res = np.argmax(pred, axis=1)\n",
+    "    return np.sum(clf_res == true).astype(np.float32)\n",
+    "\n",
+    "# 学習中の誤差を確認するための関数\n",
+    "def cross_entropy(y, t):\n",
+    "    if y.ndim == 1:\n",
+    "        t = t.reshape(1, t.size)\n",
+    "        y = y.reshape(1, y.size)\n",
+    "\n",
+    "    # 教師データがone-hot-vectorの場合、正解ラベルのインデックスに変換\n",
+    "    if t.size == y.size:\n",
+    "        t = t.argmax(axis=1)\n",
+    "\n",
+    "    batch_size = y.shape[0]\n",
+    "    return -np.sum(np.log(y[np.arange(batch_size), t] + 1e-7)) / batch_size\n",
+    "\n",
+    "\n",
+    "num_train_data = x_train.shape[0]\n",
+    "num_test_data = x_test.shape[0]\n",
+    "batch_size = 100\n",
+    "epoch_num = 10\n",
+    "learning_rate = 0.01\n",
+    "\n",
+    "epoch_list = []\n",
+    "train_loss_list = []\n",
+    "train_accuracy_list = []\n",
+    "test_accuracy_list = []\n",
+    "\n",
+    "iteration = 0\n",
+    "for epoch in range(1, epoch_num + 1):\n",
+    "    \n",
+    "    sum_accuracy = 0.0\n",
+    "    sum_loss = 0.0\n",
+    "    \n",
+    "    perm = np.random.permutation(num_train_data)\n",
+    "    for i in range(0, num_train_data, batch_size):\n",
+    "        x_batch = x_train[perm[i:i+batch_size]]\n",
+    "        y_batch = y_train[perm[i:i+batch_size]]\n",
+    "        \n",
+    "        y = model.forward(x_batch)\n",
+    "        sum_accuracy += multiclass_classification_accuracy(y, y_batch)\n",
+    "        sum_loss += cross_entropy(y, y_batch)\n",
+    "        \n",
+    "        model.backward(x_batch, y_batch)\n",
+    "        model.update_parameters(lr=learning_rate)\n",
+    "\n",
+    "        iteration += 1\n",
+    "    \n",
+    "    print(\"epoch: {}, mean loss: {}, mean accuracy: {}\".format(epoch,\n",
+    "                                                               sum_loss / num_train_data,\n",
+    "                                                               sum_accuracy / num_train_data))\n",
+    "    \n",
+    "    test_correct_count = 0\n",
+    "    for i in range(num_test_data):\n",
+    "        input = x_test[i:i+1]\n",
+    "        label = y_test[i:i+1]\n",
+    "        y = model.forward(input)\n",
+    "        \n",
+    "        test_correct_count += multiclass_classification_accuracy(y, label)\n",
+    "\n",
+    "    # 学習途中のlossと精度の保存\n",
+    "    epoch_list.append(epoch)\n",
+    "    train_loss_list.append(sum_loss / num_train_data)\n",
+    "    train_accuracy_list.append(sum_accuracy / num_train_data)\n",
+    "    test_accuracy_list.append(test_correct_count / num_test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "H_MuepUh3_sd"
+   },
+   "source": [
+    "## テスト\n",
+    "学習したネットワークを用いて，テストデータに対する認識率の確認を行います．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "id": "1U4HfEWD3_se",
+    "outputId": "38992fd9-cf76-4c1d-de0a-888013a3ea5f"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "test accuracy: 0.6481\n"
+     ]
+    }
+   ],
+   "source": [
+    "count = 0\n",
+    "num_test_data = x_test.shape[0]\n",
+    "\n",
+    "for i in range(num_test_data):\n",
+    "    x = np.array([x_test[i]], dtype=np.float32)\n",
+    "    t = y_test[i]\n",
+    "    y = model.forward(x)\n",
+    "    \n",
+    "    pred = np.argmax(y.flatten())\n",
+    "    \n",
+    "    if pred == t:\n",
+    "        count += 1\n",
+    "        \n",
+    "print(\"test accuracy: {}\".format(count / num_test_data))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FIVu8qHOJN8B"
+   },
+   "source": [
+    "## 学習推移のグラフ化"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "id": "zfePKY2xJNae"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAGwCAYAAABSN5pGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAABR5klEQVR4nO3deVhVdeLH8fe9l1VlUVAQRcEVFwRXBP21kpZmMWO5ZGrmlqlZNpZaqZOVY5PllKZpjVppbqVjak5qu+IKmPuuuAGuoCDrvb8/rDthqIjAYfm8nuc8wbnfc87nQg/341lNNpvNhoiIiIjYmY0OICIiIlLSqCCJiIiIXEcFSUREROQ6KkgiIiIi11FBEhEREbmOCpKIiIjIdVSQRERERK7jYHSA0spqtXL69Gnc3NwwmUxGxxEREZF8sNlsXL58GT8/P8zmG+8nUkEqoNOnT+Pv7290DBERESmAEydOULNmzRu+roJUQG5ubsC1H7C7u7vBaURERCQ/UlJS8Pf3t3+O34gKUgH9fljN3d1dBUlERKSUudXpMTpJW0REROQ6KkgiIiIi11FBEhEREbmOzkESEZFyw2q1kpmZaXQMKUKOjo5YLJY7Xo8KkoiIlAuZmZkcPXoUq9VqdBQpYp6envj6+t7RfQpVkEREpMyz2WycOXMGi8WCv7//TW8QKKWXzWYjLS2NpKQkAKpXr17gdakgiYhImZednU1aWhp+fn5UqFDB6DhShFxdXQFISkqiWrVqBT7cpgotIiJlXk5ODgBOTk4GJ5Hi8HsJzsrKKvA6VJBERKTc0LMzy4fC+D2rIImIiIhcRwVJRERE5DoqSCIiIiXUPffcw/PPP2/Y9s+fP0+1atU4duxYkax/7ty5eHp63tYyPXr0YMqUKUWS549UkEqYC6mZnLyYxpnkqyRdTudCaibJV7NIzcgmPSuH7BwrNpvN6JgiIlIOvPnmmzz66KMEBAQA8MMPP2Aymbh06VKhrL979+4cOHDgtpZ59dVXefPNN0lOTi6UDDeiy/xLmCnf7mf+5vhbjjObwMFsxmI24WA2YbGYsJhMub7/4+tmkwkHyx9eN//vdYv5+vkmLGYzFjNYzObc8y2//dd0bcyf12nC/Nt/HcxmKjpbqOjsQCVnB9xcHOxfV3RywGzWyZIiIiVVWloan3zyCf/9739ve9nMzMx8XTHo6upqvyw/v5o2bUrdunX5/PPPGTp06G1nyy8VpBLGYjbh7GAmx2oj23rjPUVWG2TmWCGnGMMVsopOFir9VprcnB2ufe107b9uzr+VKZdrhSrX5JL7a1dHi65MEZHbYrPZuJplzB/QO/mbdfHiRUaMGMHXX39NRkYGd999N++//z7169cH4Pjx4wwbNoxffvmFzMxMAgIC+Oc//0mnTp24ePEiw4YN49tvv+XKlSvUrFmTsWPH0q9fvzy3tXr1apydnWnbti0Ax44d49577wWgcuXKAPTt25e5c+dyzz330LRpUxwcHPj8888JDg7m+++/591332XOnDkcOXKEKlWq0KVLF95++20qVaoEXDvE9vzzz9v3SE2YMIHly5fz4osv8tprr3Hx4kUeeughZs+ejZubmz1bly5dWLhwoQpSefL6o015/dGm9u+tvxWla4XJai9OuefbyLFa7d/n/PG1nN/m2X4bk5P79Zz8rOMPr/1puzm/5bH9Ydxv28iy2kjLyObKH6f0bHvxS83MITUzB8i4o5+Z2YS9ZOVVqir+tvcqr6+vL13ODmaVLZFy4GpWDo3H3f6ekcKw5/WOVHAq2MfvU089xcGDB1mxYgXu7u68/PLLdOrUiT179uDo6MjQoUPJzMzkp59+omLFiuzZs8deRl577TX27NnDN998g7e3N4cOHeLq1as33NbPP/9My5Yt7d/7+/vz5Zdf0rVrV/bv34+7u3uuvT/z5s1jyJAhbNiwwT7PbDbz/vvvExgYyJEjR3j22Wd56aWX+PDDD2+43cOHD7N8+XJWrlzJxYsX6datG//4xz9488037WPatGnDm2++SUZGBs7OzgX6Wd6KClIJZzabcLIfirrzh+8ZzWazkZFttZel34tT6m//vZye99d/LFipGdlc/u17m+3a3rTL6dfG3ykHs+lPBcvNxYEQf08iG/nQxM9dBUpEDPF7MdqwYQMREREAzJ8/H39/f5YvX87jjz9OfHw8Xbt2JTg4GIA6derYl4+Pj6d58+a0atUKwH5e0Y0cP34cPz8/+/cWi4UqVaoAUK1atT+dXF2/fn3efvvtXPP+eIJ5QEAAb7zxBs8888xNC5LVamXu3Ln2PUa9e/dm/fr1uQqSn58fmZmZJCQkULt27Zu+j4JSQZJiZTKZcHG04OJowbvSnbX+33eRX0m/VphSrytdfyxV13/9e8n6fZlre7Ig22rjUloWl9Jy3331+/1nmbruIL7uLtzXqBqRjaoRUdcbF8fSX1pFyiNXRwt7Xu9o2LYLYu/evTg4OBAWFmaf5+XlRcOGDdm7dy8Azz33HEOGDOHbb78lMjKSrl270qxZMwCGDBlC165diYmJoUOHDkRFRdmLVl6uXr2Ki4tLvvP9cW/T79atW8ekSZPYt28fKSkpZGdnk56eTlpa2g0f+RIQEJDrcFr16tXtz1b73e97rtLS0vKd73apIEmpZTKZqODkQAUnB6rd4bpyrDbSMv9cqFIzsjl7JZOfD5zl54PnSEhJZ8HmeBZsjsfF0Uz7elWJbFSN+4KqUc09/39IRMRYv//9KGsGDBhAx44dWbVqFd9++y2TJk1iypQpDB8+nIceeojjx4+zevVq1q5dy/3338/QoUN555138lyXt7c3Fy9ezPe2K1asmOv7Y8eO8fDDDzNkyBDefPNNqlSpwi+//EL//v3JzMy8YUFydHTM9b3JZMJqteaad+HCBQCqVq2a73y3q+z93yFSABazCTcXR9xcHMHjz6/3blub9Kwcoo+cZ/3eRNbvTeJMcjrr9iaybm8iAM1qenB/kA/3N6qmQ3EiUugaNWpEdnY2mzdvtu/5OX/+PPv376dx48b2cf7+/jzzzDM888wzjBkzhtmzZzN8+HDgWqHo27cvffv25f/+7/8YNWrUDQtS8+bN+fzzz3PN+/3KtN+fbXcz27dvx2q1MmXKFMzma3cVWrx48e2/8Tzs2rWLmjVr4u3tXSjry4sKkkg+uThauLdhNe5tWI2Jj9rYcyaF7/YmsW5fEjtOXOLXk8n8ejKZ99YdoLqHC/cFVSOykQ/hdb10KE5E7lj9+vV59NFHGThwIB999BFubm6MHj2aGjVq8OijjwLXzvl56KGHaNCgARcvXuT777+nUaNGAIwbN46WLVvSpEkTMjIyWLlypf21vHTs2JExY8Zw8eJF+1VrtWvXxmQysXLlSjp16oSrq6v9JPDr1atXj6ysLD744AO6dOnChg0bmDlzZqH8LH7++Wc6dOhQKOu6Ed0oUqQATCYTTfw8GH5/ff4ztB1bXrmfyV2DeaCxD66OFs4kpzN/czz95m6l+etrGTBvGwu3xJN0Od3o6CJSis2ZM4eWLVvy8MMPEx4ejs1mY/Xq1fbDUjk5OQwdOpRGjRrx4IMP0qBBA/sJ0U5OTowZM4ZmzZpx1113YbFYWLhw4Q23FRwcTIsWLXLt9alRowZ///vfGT16ND4+PgwbNuyGy4eEhPDuu+8yefJkmjZtyvz585k0adId/wzS09NZvnw5AwcOvON13YzJptsyF0hKSgoeHh4kJyfj7u5udBwpQdKzcog+fJ51exP5bt+1Q3F/FFLTg/sbXTsU17i6DsWJFIf09HSOHj1KYGDgbZ14XN6tWrWKUaNGsWvXLvthMqPNmDGDZcuW8e23395wzM1+3/n9/NYhNpFC5uJo4d6gatwbVA2b7dqhuPV7k1i/N5EdJ5Pt07trdShOREq2zp07c/DgQU6dOoW/v7/RcYBrJ3F/8MEHRb4d7UEqIO1BkoJISknnu31JrNubxC+HzpKe9b8rM1wdLbSv701ko2vlqpqb/pUrUli0B6l80R4kkVKmmrsLPdrUokebWrkOxa3fm0RCSjpr9ySyds+1q+JC/D25P6iaDsWJiBhAe5AKSHuQpDDZbDZ2n/7tUNy+RH49mfsp1X4e125QeX8jH8Lr6FCcyO36fY9CQEDAbT8cVUqfq1evcuzYsTvag6SCVEAqSFKUElPS+f4Gh+IqOFloX8+byEY+3BNUVYfiRPIhKyuLQ4cO4efnh4dHHjc7kzLl/PnzJCUl0aBBAyyW3P+gVEEqYipIUlzSs3LYePgc6/Ym8d1vh+L+KMTfk8iga3uXGlV306E4kTzYbDbi4+PJysrCz8+vxFyRJYXLZrORlpZGUlISnp6eVK9e/U9jVJCKmAqSGOH3Q3G/30Igr0Nxv99CoK0OxYnkkpmZydGjR//02Aopezw9PfH19c3zH4wqSEVMBUlKgsTfropbvzeRXw6du+GhuHuDqlHV7c4eDixSFlitVjIzM42OIUXI0dHxT4fV/kgFqYipIElJk56Vw4ZDvx2K25dIYkqG/TWTCUJqejLi/vrcG3Snj/YVESm9VJCKmAqSlGR/PBS3fm8SO09dOxTnZDHzxaAwWtauYnBCERFjqCAVMRUkKU0SU9J5bfkuvt2TiFdFJ/4zrB01K1cwOpaISLHL7+e3TuMXKQd83F2Y2iOUJn7unE/NZMC8baRmZBsdS0SkxFJBEiknKjg5MLtPK7wrObMv4TIvLIrDatUOZBGRvKggiZQjfp6uzOrTEicHM9/uSeSdb/cbHUlEpERSQRIpZ1rUqszbXZsB8OEPh1kWe9LgRCIiJY8Kkkg5FNW8Bs/eUxeAl7/cSUz8RYMTiYiULCpIIuXU3zo05IHGPmRmWxn06XZOX7pqdCQRkRJDBUmknDKbTUztHkqQrxvnrmQwYN420jJ1ZZuICKggiZRrFZ0d+LhvK7wqOrHnTAovLt6hK9tERCghBWn69OkEBATg4uJCWFgYW7Zsuen4JUuWEBQUhIuLC8HBwaxevdr+WlZWFi+//DLBwcFUrFgRPz8/+vTpw+nTp+1jjh07Rv/+/QkMDMTV1ZW6desyfvx4PZ9HyqWalSvwUe+WOFnMfLMrganrDhgdSUTEcIYXpEWLFjFy5EjGjx9PTEwMISEhdOzYkaSkpDzHb9y4kZ49e9K/f39iY2OJiooiKiqKXbt2AZCWlkZMTAyvvfYaMTExfPXVV+zfv59HHnnEvo59+/ZhtVr56KOP2L17N++99x4zZ85k7NixxfKeRUqaVgFVeOuvwQC8/90hVuw4fYslRETKNsMfNRIWFkbr1q2ZNm0acO1Jy/7+/gwfPpzRo0f/aXz37t1JTU1l5cqV9nlt27YlNDSUmTNn5rmNrVu30qZNG44fP06tWrXyHPPPf/6TGTNmcOTIkXzl1qNGpCyatHovH/10BGcHM4sHhxPi72l0JBGRQlUqHjWSmZnJ9u3biYyMtM8zm81ERkYSHR2d5zLR0dG5xgN07NjxhuMBkpOTMZlMeHp63nRMlSo3foBnRkYGKSkpuSaRsualB4O4P6gaGdlWBn66jYTkdKMjiYgYwtCCdO7cOXJycvDx8ck138fHh4SEhDyXSUhIuK3x6enpvPzyy/Ts2fOGTfHQoUN88MEHDB48+IZZJ02ahIeHh33y9/e/2VsTKZUsZhNTe4TSwKcSSZczGPjpNq5m5hgdS0Sk2Bl+DlJRysrKolu3bthsNmbMmJHnmFOnTvHggw/y+OOPM3DgwBuua8yYMSQnJ9unEydOFFVsEUO5uTjySd/WVK7gyM5Tyfxt6Q4MPhIvIlLsDC1I3t7eWCwWEhMTc81PTEzE19c3z2V8fX3zNf73cnT8+HHWrl2b596j06dPc++99xIREcGsWbNumtXZ2Rl3d/dck0hZ5V+lAjOfbImjxcSqX8/w/vpDRkcSESlWhhYkJycnWrZsyfr16+3zrFYr69evJzw8PM9lwsPDc40HWLt2ba7xv5ejgwcPsm7dOry8vP60nlOnTnHPPffQsmVL5syZg9lcpnemidy2sDpevBHVFID31h1g1a9nDE4kIlJ8HIwOMHLkSPr27UurVq1o06YNU6dOJTU1lX79+gHQp08fatSowaRJkwAYMWIEd999N1OmTKFz584sXLiQbdu22fcAZWVl8dhjjxETE8PKlSvJycmxn59UpUoVnJyc7OWodu3avPPOO5w9e9ae50Z7rkTKo+6ta3Eg8Qqf/HKUF5fEUatKBYJrehgdS0SkyBlekLp3787Zs2cZN24cCQkJhIaGsmbNGvuJ2PHx8bn27kRERLBgwQJeffVVxo4dS/369Vm+fDlNm177l+6pU6dYsWIFAKGhobm29f3333PPPfewdu1aDh06xKFDh6hZs2auMTrXQiS3MQ8FcSjpCj8eOMvAT7exYlg7qrm7GB1LRKRIGX4fpNJK90GS8iQlPYu/friRQ0lXCPH3ZNGgtrg4WoyOJSJy20rFfZBEpHRwd3Hkk76t8KzgyI4Tl3hp6a/a2yoiZZoKkojkS22vinzYqwUOZhMrdpzmwx8OGx1JRKTIqCCJSL5F1PXm7482AeCf/93Pml1536BVRKS0U0ESkdvSK6w2T0UEAPDCojh2n042NpCISBFQQRKR2/Zq50b8X31vrmblMHDeNpIu65ltIlK2qCCJyG1zsJiZ1rMFdbwrcjo5ncGfbSc9S89sE5GyQwVJRArEo4IjH/dthbuLA7Hxlxj71U5d2SYiZYYKkogUWJ2qlfiwV0ssZhNfxZ5i5o9HjI4kIlIoVJBE5I60r+/N+C6NAXj7v/tYuyfxFkuIiJR8Kkgicsf6hAfwZNta2Gzw/MJY9iWkGB1JROSOqCCJSKEY36UJEXW9SM3Mof/cbZy7kmF0JBGRAlNBEpFC4Wgx82GvFgR4VeDUpasM+Xw7Gdm6sk1ESicVJBEpNJ4VnPi4b2vcXBzYeuwiry7bpSvbRKRUUkESkUJVr1olpj3RArMJlmw/ycc/HzU6kojIbVNBEpFCd3eDqrza+dqVbW99s5fv9unKNhEpXVSQRKRI9GsXQM82/ths8NwXcRxIvGx0JBGRfFNBEpEiYTKZ+PsjTQkLrMKVjGz6z9vKhdRMo2OJiOSLCpKIFBknBzMznmxJrSoVOHHhKs98vp3MbKvRsUREbkkFSUSKVJWKTnzctxWVnB3YcvQC4/6jK9tEpORTQRKRItfAx40PejbHbIKFW08wZ8MxoyOJiNyUCpKIFIt7g6oxtlMjAN5YtYcf9icZnEhE5MZUkESk2PRvH8jjLWtitcHwBbEcSrpidCQRkTypIIlIsTGZTLzxl6a0DqjM5YxsBszbyqU0XdkmIiWPCpKIFCtnBwszn2xJDU9Xjp1P49n5MWTl6Mo2ESlZVJBEpNh5VXLmk6daUdHJwsbD55mwYreubBOREkUFSUQMEeTrzr96NMdkgvmb4/ls03GjI4mI2KkgiYhhIhv78PKDQQD8/es9/HzwrMGJRESuUUESEUMNvqsOf21RgxyrjaHzYzhyVle2iYjxVJBExFAmk4m3/hJMi1qepKRnM2DeNpLTsoyOJSLlnAqSiBjOxdHCR71b4efhwpFzqQxdEEO2rmwTEQOpIIlIiVDVzZnZfVvh6mjhl0PnmLhyj9GRRKQcU0ESkRKjiZ8H73UPBWBe9HE+15VtImIQFSQRKVEebOrLqI4NAZiwYjcbD58zOJGIlEcqSCJS4jx7T10eDfUj22pjyOcxHDuXanQkESlnVJBEpMQxmUxM7tqMEH9Pkq9m0X/eVpKv6so2ESk+KkgiUiK5OFqY3bslvu4uHD6byvAvYnVlm4gUGxUkESmxqrm78HHfVrg4mvnpwFneWr3P6EgiUk6oIIlIida0hgfvdgsF4N8bjrJwS7yxgUSkXFBBEpESr1NwdV6IbADAq8t3senIeYMTiUhZp4IkIqXCc/fX4+Fm1cm22hi2IIbzVzKMjiQiZZgKkoiUCiaTiX8+FkIDn0qcu5LJ2GU7sdlsRscSkTJKBUlESg1XJwvvdgvF0WLiv7sT+TLmlNGRRKSMUkESkVKlaQ0Pnv/tfKS/r9jNyYtpBicSkbJIBUlESp3Bd9WheS1PLmdkM2rJr1itOtQmIoVLBUlESh0Hi5l3u4Xi6mgh+sh55mw8ZnQkESljVJBEpFQK9K7I2M6NAJi8Zh8HEy8bnEhEyhIVJBEptZ4Mq8XdDaqSmW3lhcVxZOlRJCJSSFSQRKTUMplMvP1YMzxcHdl1KoUP1h80OpKIlBEqSCJSqvm4u/BGVFMApv9wmNj4iwYnEpGyQAVJREq9LiF+PBLiR47VxouLd3A1M8foSCJSyqkgiUiZ8PqjTfBxd+bIuVT+8c1eo+OISCmngiQiZYJnBSf++VgIAPOij/PzwbMGJxKR0kwFSUTKjLsaVKV329oAjFryK8lpWQYnEpHSqkQUpOnTpxMQEICLiwthYWFs2bLlpuOXLFlCUFAQLi4uBAcHs3r1avtrWVlZvPzyywQHB1OxYkX8/Pzo06cPp0+fzrWOCxcu0KtXL9zd3fH09KR///5cuXKlSN6fiBSfMZ2CCPSuSEJKOuNW7DI6joiUUoYXpEWLFjFy5EjGjx9PTEwMISEhdOzYkaSkpDzHb9y4kZ49e9K/f39iY2OJiooiKiqKXbuu/SFMS0sjJiaG1157jZiYGL766iv279/PI488kms9vXr1Yvfu3axdu5aVK1fy008/MWjQoCJ/vyJStCo4OTClWwhmE/wn7jQrfz1964VERK5jstlshj7EKCwsjNatWzNt2jQArFYr/v7+DB8+nNGjR/9pfPfu3UlNTWXlypX2eW3btiU0NJSZM2fmuY2tW7fSpk0bjh8/Tq1atdi7dy+NGzdm69attGrVCoA1a9bQqVMnTp48iZ+f35/WkZGRQUZGhv37lJQU/P39SU5Oxt3d/Y5+BiJS+KZ8u58PvjuEZwVHvn3+Lqq5uxgdSURKgJSUFDw8PG75+W3oHqTMzEy2b99OZGSkfZ7ZbCYyMpLo6Og8l4mOjs41HqBjx443HA+QnJyMyWTC09PTvg5PT097OQKIjIzEbDazefPmPNcxadIkPDw87JO/v39+36aIGGD4ffVp4ufOpbQsXvryVwz+t6CIlDKGFqRz586Rk5ODj49Prvk+Pj4kJCTkuUxCQsJtjU9PT+fll1+mZ8+e9qaYkJBAtWrVco1zcHCgSpUqN1zPmDFjSE5Otk8nTpzI13sUEWM4OZiZ2j0UJwczP+w/y4It8UZHEpFSxPBzkIpSVlYW3bp1w2azMWPGjDtal7OzM+7u7rkmESnZ6vu48VLHhgC8sXIvx86lGpxIREoLQwuSt7c3FouFxMTEXPMTExPx9fXNcxlfX998jf+9HB0/fpy1a9fmKjS+vr5/Ogk8OzubCxcu3HC7IlI6Pd0ukLZ1qnA1K4eRi+PIsepQm4jcmqEFycnJiZYtW7J+/Xr7PKvVyvr16wkPD89zmfDw8FzjAdauXZtr/O/l6ODBg6xbtw4vL68/rePSpUts377dPu+7777DarUSFhZWGG9NREoIs9nEO4+HUMnZgZj4S8z88bDRkUSkFDD8ENvIkSOZPXs28+bNY+/evQwZMoTU1FT69esHQJ8+fRgzZox9/IgRI1izZg1Tpkxh3759TJgwgW3btjFs2DDgWjl67LHH2LZtG/PnzycnJ4eEhAQSEhLIzMwEoFGjRjz44IMMHDiQLVu2sGHDBoYNG0aPHj3yvIJNREq3mpUrML5LYwCmrjvA7tPJBicSkZLO8ILUvXt33nnnHcaNG0doaChxcXGsWbPGfiJ2fHw8Z86csY+PiIhgwYIFzJo1i5CQEJYuXcry5ctp2vTa07xPnTrFihUrOHnyJKGhoVSvXt0+bdy40b6e+fPnExQUxP3330+nTp1o3749s2bNKt43LyLF5rGWNenQ2IesHBsjF+0gPUsPtBWRGzP8PkilVX7voyAiJce5Kxk8OPUnzl3JZPBddRjTqZHRkUSkmJWK+yCJiBQn70rOvPWXYABm/XyEzUfOG5xIREoqFSQRKVc6NPHl8ZY1sdngxSU7uJKRbXQkESmBVJBEpNwZ16UxNSu7cvLiVSZ+vcfoOCJSAqkgiUi54+biyDuPh2AywaJtJ1i3J/HWC4lIuaKCJCLlUts6XgxoHwjA6K9+5fyVjFssISLliQqSiJRbL3ZoSAOfSpy7ksnYZTv1QFsRsVNBEpFyy8XRwrvdQnG0mPjv7kS+ijlldCQRKSFUkESkXGtaw4PnIxsAMGHFbk5dumpwIhEpCVSQRKTcG3xXHZrX8uRyRjZ/W7wDqx5oK1LuqSCJSLnnYDHzbrdQXB0tRB85z5yNx4yOJCIGU0ESEQECvSsytvO1R49MXrOPg4mXDU4kIkZSQRIR+c2TYbW4u0FVMrOtjFy8g6wcq9GRRMQgKkgiIr8xmUy8/VgzPFwd2XkqmQ++O2R0JBExiAqSiMgf+Li78EZUUwCmf3+IuBOXjA0kIoZQQRIRuU6XED8eCfEjx2pj5KI4rmbmGB1JRIqZCpKISB5ef7QJPu7OHDmXyj++2Wt0HBEpZipIIiJ58KzgxD8fCwFgXvRxfj541uBEIlKcVJBERG7grgZV6d22NgCjlvxKclqWwYlEpLioIImI3MSYTkEEelckISWd8St2GR1HRIqJCpKIyE1UcHJgSrcQzCZYHneaVb+eMTqSiBQDFSQRkVtoUasyQ++tB8Ary3eSlJJucCIRKWoqSCIi+TD8vvo08XPnUloWL335KzabHmgrUpapIImI5IOTg5mp3UNxcjDzw/6zfLHlhNGRRKQIqSCJiORTfR83XurYEIA3Vu3h+PlUgxOJSFFRQRIRuQ1PtwukbZ0qpGXmMHLxDnKsOtQmUhapIImI3Aaz2cQ7j4dQydmB7ccv8tFPh42OJCJFQAVJROQ21axcgfFdGgPw3toD7D6dbHAiESlsKkgiIgXwWMuadGjsQ1aOjZGLdpCRrQfaipQlKkgiIgVgMpl466/BeFdyYn/iZd799oDRkUSkEKkgiYgUkHclZ976SzAAs34+wpajFwxOJCKFRQVJROQOdGjiy+Mta2KzwYtL4riSkW10JBEpBCpIIiJ3aFyXxtSs7MqJC1d5Y+Ueo+OISCFQQRIRuUNuLo6883gIJhMs3HqCdXsSjY4kIndIBUlEpBC0rePFgPaBAIz+6lfOX8kwOJGI3AkVJBGRQvJih4Y08KnEuSuZvLJslx5oK1KKqSCJiBQSF0cL73YLxdFiYs3uBJbFnjI6kogUkAqSiEghalrDg+cjGwAw/j+7OXXpqsGJRKQgVJBERArZ4Lvq0LyWJ5czshm1ZAdWPdBWpNRRQRIRKWQOFjPvdgvF1dHCxsPnmbvxmNGRROQ2qSCJiBSBQO+KjO3cCIDJa/ZxKOmywYlE5HaoIImIFJEnw2pxd4OqZGRbeWHRDrJyrEZHEpF8UkESESkiJpOJtx9rhoerIztPJfPBd4eMjiQi+aSCJCJShHzcXXgjqikA078/RNyJS8YGEpF8UUESESliXUL8eCTEjxyrjZGL4riamWN0JBG5BRUkEZFi8PqjTfBxd+bIuVQmr9lndBwRuQUVJBGRYuBZwYl/PhYCwNyNx/j54FmDE4nIzaggiYgUk7saVKV329oAjFryK8lpWQYnEpEbUUESESlGYzoFEehdkYSUdF5ZvlN32RYpoVSQRESKUQUnB97tFoLFbGLlr2dUkkRKKBUkEZFi1rxWZf75WDPMJvhiywle+vJXclSSREoUFSQREQP8tUVN3useisVsYun2k/xtyQ6ydadtkRJDBUlExCCPhtbg/R7NcTCbWBZ7ihcWqySJlBSGF6Tp06cTEBCAi4sLYWFhbNmy5abjlyxZQlBQEC4uLgQHB7N69epcr3/11Vd06NABLy8vTCYTcXFxf1pHQkICvXv3xtfXl4oVK9KiRQu+/PLLwnxbIiL50rlZdaY90QJHi4mvd5xm+BexemabSAlgaEFatGgRI0eOZPz48cTExBASEkLHjh1JSkrKc/zGjRvp2bMn/fv3JzY2lqioKKKioti1a5d9TGpqKu3bt2fy5Mk33G6fPn3Yv38/K1asYOfOnfz1r3+lW7duxMbGFvp7FBG5lQeb+jKjV0ucLGa+2ZXAs/NjyMjW3bZFjGSy2WyGnRkYFhZG69atmTZtGgBWqxV/f3+GDx/O6NGj/zS+e/fupKamsnLlSvu8tm3bEhoaysyZM3ONPXbsGIGBgcTGxhIaGprrtUqVKjFjxgx69+5tn+fl5cXkyZMZMGBAvrKnpKTg4eFBcnIy7u7u+X3LIiI39P3+JAZ/tp3MbCv3BVXjw14tcHG0GB1LpEzJ7+e3YXuQMjMz2b59O5GRkf8LYzYTGRlJdHR0nstER0fnGg/QsWPHG46/kYiICBYtWsSFCxewWq0sXLiQ9PR07rnnnhsuk5GRQUpKSq5JRKQw3duwGp/0bYWzg5nv9iUx6LPtpGdpT5KIEQpUkObNm8eqVavs37/00kt4enoSERHB8ePH87WOc+fOkZOTg4+PT675Pj4+JCQk5LlMQkLCbY2/kcWLF5OVlYWXlxfOzs4MHjyYZcuWUa9evRsuM2nSJDw8POyTv7//bW1TRCQ//q9+Veb0a42ro4WfDpxlwLxteritiAEKVJDeeustXF1dgWt7daZPn87bb7+Nt7c3L7zwQqEGLAqvvfYaly5dYt26dWzbto2RI0fSrVs3du7cecNlxowZQ3Jysn06ceJEMSYWkfIkoq43c/u1poKThV8OnaPf3C2kZmQbHUukXHEoyEInTpyw721Zvnw5Xbt2ZdCgQbRr1+6mh6n+yNvbG4vFQmJiYq75iYmJ+Pr65rmMr6/vbY3Py+HDh5k2bRq7du2iSZMmAISEhPDzzz8zffr0P53L9DtnZ2ecnZ3zvR0RkTsRVseLz/q3oe+/t7LpyAWemrOFOf3aUMm5QH+2ReQ2FWgPUqVKlTh//jwA3377LQ888AAALi4uXL16NV/rcHJyomXLlqxfv94+z2q1sn79esLDw/NcJjw8PNd4gLVr195wfF7S0tKAa+c7/ZHFYsFq1aW1IlJytKxdhc8HhOHm4sDWYxfp/clmUtL1gFuR4lCggvTAAw8wYMAABgwYwIEDB+jUqRMAu3fvJiAgIN/rGTlyJLNnz2bevHns3buXIUOGkJqaSr9+/YBrl+OPGTPGPn7EiBGsWbOGKVOmsG/fPiZMmMC2bdsYNmyYfcyFCxeIi4tjz549AOzfv5+4uDj7eUpBQUHUq1ePwYMHs2XLFg4fPsyUKVNYu3YtUVFRBflxiIgUmVB/TxYMaIuHqyOx8Zfo/fFmktNUkkSKWoEK0vTp0wkPD+fs2bN8+eWXeHl5AbB9+3Z69uyZ7/V0796dd955h3HjxhEaGkpcXBxr1qyxn4gdHx/PmTNn7OMjIiJYsGABs2bNIiQkhKVLl7J8+XKaNm1qH7NixQqaN29O586dAejRowfNmze3HzpzdHRk9erVVK1alS5dutCsWTM+/fRT5s2bZy96IiIlSXBNDxYMDKNyBUd2nEym1yebuJiaaXQskTLN0PsglWa6D5KIFLd9CSn0mr2Z86mZBPm6MX9AGF6VdG6kyO0o0vsgrVmzhl9++cX+/fTp0wkNDeWJJ57g4sWLBVmliIjcQpCvOwsHtcW7kjP7Ei7Tc/Ymzl7OMDqWSJlUoII0atQo+40Sd+7cyYsvvkinTp04evQoI0eOLNSAIiLyP/V93Fg0uC0+7s4cSLxCj1nRJKWkGx1LpMwpUEE6evQojRs3BuDLL7/k4Ycf5q233mL69Ol88803hRpQRERyq1u1EosGhVPdw4XDZ1PpPmsTZ5LzdwWxiORPgQqSk5OT/XL5devW0aFDBwCqVKmiR3CIiBSDAO+KLB4cTg1PV46eS6X7R5s4dUklSaSwFKggtW/fnpEjRzJx4kS2bNliv2LswIED1KxZs1ADiohI3vyrVGDR4LbUqlKB+AtpdP8omhMX0oyOJVImFKggTZs2DQcHB5YuXcqMGTOoUaMGAN988w0PPvhgoQYUEZEbq1n5WkkK8KrAyYtX6f5RNMfPpxodS6TU02X+BaTL/EWkJElMSafn7E0cOZuKr7sLCwaGUadqJaNjiZQ4+f38LnBBysnJYfny5ezduxeAJk2a8Mgjj2CxWAqWuJRRQRKRkibpcjq9Zm/mYNIVqro588XAMOpVczM6lkiJUqQF6dChQ3Tq1IlTp07RsGFD4NojPfz9/Vm1ahV169YtePJSQgVJREqi81cy6PXxZvYlXMa7khPzB7Sloa9KksjvivRGkc899xx169blxIkTxMTEEBMTQ3x8PIGBgTz33HMFDi0iInfGq5IzCwa2pXF1d85dyaTn7E3sOa2ri0VuV4H2IFWsWJFNmzYRHByca/6OHTto164dV65cKbSAJZX2IIlISXYpLZPen2xh56lkPCs48nn/MJrW8DA6lojhinQPkrOzM5cvX/7T/CtXruDk5FSQVYqISCHyrODE5wPCCPX35FJaFk/M3sSOE5eMjiVSahSoID388MMMGjSIzZs3Y7PZsNlsbNq0iWeeeYZHHnmksDOKiEgBeLg68ln/NrSqXZmU9Gye/Hgz24/reZki+VGggvT+++9Tt25dwsPDcXFxwcXFhYiICOrVq8fUqVMLOaKIiBSUm4sj855uQ5vAKlzOyKbPJ5vZeuyC0bFESrw7ug/SoUOH7Jf5N2rUiHr16hVasJJO5yCJSGmSlpnNgHnb2Hj4PBWcLHzStzXhdb2MjiVS7Ar9Mv+RI0fme+PvvvtuvseWVipIIlLaXM3MYdBn2/j54DlcHM183Kc17et7Gx1LpFjl9/PbIb8rjI2Nzdc4k8mU31WKiEgxcnWyMLtPK4Z8vp3v95+l/7ytzOrTirsbVDU6mkiJo0eNFJD2IIlIaZWRncPQ+bGs25uIk8XMzN4tuC/Ix+hYIsWiSC/zFxGR0svZwcKHvVrwYBNfMnOsDP5sO9/uTjA6lkiJooIkIlIOOTmY+eCJ5nRuVp2sHBvPzo9h9c4zRscSKTFUkEREyilHi5l/dQ/l0VA/sq02hn8Ry9c7ThsdS6REUEESESnHHCxm3u0WStcWNcmx2hixMJZlsSeNjiViOBUkEZFyzmI28c/HmtG9lT9WG4xcvIMl204YHUvEUCpIIiKC2Wxi0l+D6RVWC5sNRi39lS+2xBsdS8QwKkgiIgJcK0lvRDXlqYgAAMZ8tZPPoo8ZmknEKCpIIiJiZzKZGN+lMQPaBwLw2n92M2fDUYNTiRQ/FSQREcnFZDLxSudGPHN3XQD+/vUeZv90xOBUIsVLBUlERP7EZDLx8oMNGX7ftYeQv7l6Lx/+cMjgVCLFRwVJRETyZDKZeLFDQ16IbADA22v28691Bw1OJVI8VJBEROSmRkTWZ1THhgC8t+4A7367Hz3GU8o6FSQREbmloffWY2ynIADe/+4Qb/9XJUnKNhUkERHJl0F31WXcw40BmPHDYd5avVclScosFSQREcm3p9sHMvHRJgDM/vkof/96j0qSlEkqSCIiclt6hwfw1l+CAZi78RivLt+F1aqSJGWLCpKIiNy2J8Jq8fZjzTCZYP7meIYvjCUjO8foWCKFRgVJREQKpFsrf/7VozmOFhOrfj1DvzlbuZyeZXQskUKhgiQiIgX2SIgfc55qQ0UnCxsPn6fHrE0kXU43OpbIHVNBEhGRO9K+vjcLB4XjXcmJ3adTeGxGNMfOpRodS+SOqCCJiMgdC67pwdJnIqhVpQLxF9LoOmMjO08mGx1LpMBUkEREpFAEeFfkyyERNPFz53xqJj1mRfPzwbNGxxIpEBUkEREpNFXdnFk4qC3t6nmRmpnD03O38p+4U0bHErltKkgiIlKo3Fwc+fdTrXm4WXWycmyMWBjHJ78cNTqWyG1RQRIRkULn7GDh/R7NeSoiAICJK/cw6Rs9mkRKDxUkEREpEmazifFdGvPSgw0B+OjHI7y4ZAdZOVaDk4ncmgqSiIgUGZPJxLP31OOfjzXDYjbxVcwpBn66jbTMbKOjidyUCpKIiBS5x1v5M7tPS1wczfyw/yxPzN7MhdRMo2OJ3JAKkoiIFIv7gnyYP6AtnhUciTtxicdmbuTkxTSjY4nkSQVJRESKTcvalVn6TDh+Hi4cOZtK1xkb2ZeQYnQskT9RQRIRkWJVr5obXz4bQQOfSiSmZPD4zGg2HzlvdCyRXFSQRESk2FX3cGXJ4AhaB1Tmcno2vf+9hTW7zhgdS8ROBUlERAzhUcGRz/qH8UBjHzKzrTw7P4bPNx03OpYIoIIkIiIGcnG0MKNXC3q2qYXVBq8u38V7aw/ohpJiOBUkERExlIPFzFt/acpz99cH4F/rDzJ22S5yrCpJYhzDC9L06dMJCAjAxcWFsLAwtmzZctPxS5YsISgoCBcXF4KDg1m9enWu17/66is6dOiAl5cXJpOJuLi4PNcTHR3NfffdR8WKFXF3d+euu+7i6tWrhfW2RETkNphMJkY+0ICJUU0xmeCLLfEM+Xw76Vk5RkeTcsrQgrRo0SJGjhzJ+PHjiYmJISQkhI4dO5KUlJTn+I0bN9KzZ0/69+9PbGwsUVFRREVFsWvXLvuY1NRU2rdvz+TJk2+43ejoaB588EE6dOjAli1b2Lp1K8OGDcNsNrwvioiUa73b1ubDJ1rgZDHz7Z5E+nyyheSrWUbHknLIZDPwQG9YWBitW7dm2rRpAFitVvz9/Rk+fDijR4/+0/ju3buTmprKypUr7fPatm1LaGgoM2fOzDX22LFjBAYGEhsbS2hoaK7X2rZtywMPPMDEiRPznTUjI4OMjAz79ykpKfj7+5OcnIy7u3u+1yMiIre26ch5Bs7bxuWMbBr6uDHv6Tb4ergYHUvKgJSUFDw8PG75+W3YLpPMzEy2b99OZGTk/8KYzURGRhIdHZ3nMtHR0bnGA3Ts2PGG4/OSlJTE5s2bqVatGhEREfj4+HD33Xfzyy+/3HS5SZMm4eHhYZ/8/f3zvU0REbk9bet4sfiZcKq5ObM/8TJdZ2zkUNIVo2NJOWJYQTp37hw5OTn4+Pjkmu/j40NCQkKeyyQkJNzW+LwcOXIEgAkTJjBw4EDWrFlDixYtuP/++zl48OANlxszZgzJycn26cSJE/nepoiI3L5G1d35ckgEdbwrcurSVR6buZGY+ItGx5JyotyddGO1WgEYPHgw/fr1o3nz5rz33ns0bNiQf//73zdcztnZGXd391yTiIgULf8qFVjyTDgh/p5cSsviidmb+H5f3uepihQmwwqSt7c3FouFxMTEXPMTExPx9fXNcxlfX9/bGp+X6tWrA9C4ceNc8xs1akR8fHy+1yMiIsXDq5IzXwwM4+4GVUnPsjLg020s2aa9+FK0DCtITk5OtGzZkvXr19vnWa1W1q9fT3h4eJ7LhIeH5xoPsHbt2huOz0tAQAB+fn7s378/1/wDBw5Qu3bt23gHIiJSXCo4OfBx31b8tXkNcqw2Ri39lRk/HNYNJaXIOBi58ZEjR9K3b19atWpFmzZtmDp1KqmpqfTr1w+APn36UKNGDSZNmgTAiBEjuPvuu5kyZQqdO3dm4cKFbNu2jVmzZtnXeeHCBeLj4zl9+jSAvQj5+vri6+uLyWRi1KhRjB8/npCQEEJDQ5k3bx779u1j6dKlxfwTEBGR/HK0mHnn8RCqujnz0U9HmLxmH0mX03mtc2PMZpPR8aSMMbQgde/enbNnzzJu3DgSEhIIDQ1lzZo19hOx4+Pjc92bKCIiggULFvDqq68yduxY6tevz/Lly2natKl9zIoVK+wFC6BHjx4AjB8/ngkTJgDw/PPPk56ezgsvvMCFCxcICQlh7dq11K1btxjetYiIFJTZbGJMp0ZUdXPmjVV7mbPhGOeuZPLO481wdrAYHU/KEEPvg1Sa5fc+CiIiUjSWx57ib0t2kG210b6eNzN7t6SSs6H/7pdSoMTfB0lERORORDWvwb+fak0FJwu/HDpHj1nRnL2ccesFRfJBBUlEREqtuxpUZeGgtnhVdGLXqRQem7mR4+dTjY4lZYAKkoiIlGrNanqydEgE/lVcOX4+ja4zNrLrVLLRsaSUU0ESEZFSL9C7Il8OiaBxdXfOXcmk+0fRbDh0zuhYUoqpIImISJlQzc2FRYPbEl7Hi9TMHJ6as4UVO04bHUtKKRUkEREpM9xcHJn7dGs6B1cnK8fGc1/EMmfDUaNjSSmkgiQiImWKs4OF93s2p2/4tacj/P3rPUxes0933ZbbooIkIiJljsVsYsIjTRjVsSEAM344zKilv5KVYzU4mZQWKkgiIlImmUwmht5bj8ldgzGbYOn2kwz+bDtXM3OMjialgAqSiIiUad1b12JW71Y4O5j5bl8ST3y8iYupmUbHkhJOBUlERMq8yMY+LBgYhoerI7Hxl3hs5kZOXbpqdCwpwVSQRESkXGhZuwpLnwmnuocLh8+m8tcPN7A/4bLRsaSEUkESEZFyo76PG18OiaB+tUokpmTw+MyNbDl6wehYUgKpIImISLni5+nKkmfCaVW7Minp2Tz5yWb+uzvB6FhSwqggiYhIueNZwYnP+ocR2agamdlWhny+nQWb442OJSWICpKIiJRLrk4WZj7Zku6t/LHaYOyynXz4wyGjY0kJoYIkIiLlloPFzD+6BjP03roAvL1mP//4RnfdFhUkEREp50wmE6M6BjHmoSAAZv54mFeX78JqVUkqz1SQREREgMF312XSX4MxmWD+5nheWBynR5OUYypIIiIiv+nZphbv92iOg9nEf+JO88xn20nP0qNJyiMVJBERkT/oEuLH7D7XHk2yfl8ST83ZwpWMbKNjSTFTQRIREbnOvUHVmPd0Gyo5O7DpyAV6zdbz28obFSQREZE8tK3jxYKBYVSu4MiOk8l0nxVNYkq60bGkmKggiYiI3ECzmp4sHhyOj7szBxKv8PjMaE5cSDM6lhQDFSQREZGbqO/jxtJnIqhVpQLxF9J4bOZGDibqIbdlnQqSiIjILfhXqcDSZ8Jp4HPtIbfdPorm15OXjI4lRUgFSUREJB+qubuwaFA4ITU9uJiWxROzN7PpyHmjY0kRUUESERHJp8oVnZg/sC1t61ThSkY2ff+9he/2JRodS4qACpKIiMhtqOTswNx+bYhsVI2MbCuDPt3Oih2njY4lhUwFSURE5Da5OFqY8WRLHg31I9tqY8TCWBZsjjc6lhQiFSQREZECcLSYea9bKL3CamGzwdhlO5n102GjY0khUUESEREpILPZxBtRTXnm7roAvLV6H+/8dz82m83gZHKnVJBERETugMlkYvRDQbz0YEMApn1/iPErdmO1qiSVZipIIiIiheDZe+oxMaopJhN8Gn2cF5fsIDvHanQsKSAVJBERkULSu21t3usWisVsYlnsKYbMjyE9K8foWFIAKkgiIiKFKKp5DT56siVODmbW7kmk/7ytpGZkGx1LbpMKkoiISCGLbOzD3H6tqehkYcOh8zz5yWYupWUaHUtugwqSiIhIEYio683nA8LwcHUkNv4SPWZtIulyutGxJJ9UkERERIpI81qVWTw4nKpuzuxLuEy3mdGcvJhmdCzJBxUkERGRItTQ142lz4RTs7Irx86n8fjMaA4lXTE6ltyCCpKIiEgRq+1VkaXPRFCvWiXOJKfT/aNodp1KNjqW3IQKkoiISDHw9XBh8eBwgmt4cD41k56zNrH12AWjY8kNqCCJiIgUkyoVnZg/MIw2AVW4nJFN708288P+JKNjSR5UkERERIqRu4sj855uwz0Nq5KeZWXgp9tYvfOM0bHkOipIIiIixczVycKs3q14uFl1snJsDFsQw+KtJ4yOJX+ggiQiImIAJwcz/+rRnJ5t/LHa4KUvf+WTX44aHUt+o4IkIiJiEIvZxFt/CWbQXXUAmLhyD++tPYDNZjM4maggiYiIGMhkMjHmoSD+1qEBAP9af5DXV+7BalVJMpIKkoiIiMFMJhPD7qvP3x9pAsCcDcd46ctfyc6xGpys/FJBEhERKSH6RgQw5fEQLGYTS7efZPgXsWRk5xgdq1xSQRIRESlBurasyYe9WuBkMfPNrgQGzNtGWma20bHKHRUkERGREqZjE1/+/VRrXB0t/HzwHL0/2ULy1SyjY5UrJaIgTZ8+nYCAAFxcXAgLC2PLli03Hb9kyRKCgoJwcXEhODiY1atX53r9q6++okOHDnh5eWEymYiLi7vhumw2Gw899BAmk4nly5cXwrsRERG5c+3re/P5gDDcXRzYfvwiPWdt4tyVDKNjlRuGF6RFixYxcuRIxo8fT0xMDCEhIXTs2JGkpLxvvb5x40Z69uxJ//79iY2NJSoqiqioKHbt2mUfk5qaSvv27Zk8efIttz916lRMJlOhvR8REZHC0rJ2ZRYOCse7khN7zqTQbWY0py9dNTpWuWCyGXyzhbCwMFq3bs20adMAsFqt+Pv7M3z4cEaPHv2n8d27dyc1NZWVK1fa57Vt25bQ0FBmzpyZa+yxY8cIDAwkNjaW0NDQP60rLi6Ohx9+mG3btlG9enWWLVtGVFRUvnKnpKTg4eFBcnIy7u7u+X/DIiIit+nouVSe/Hgzpy5dpYanK5/1b0OdqpWMjlUq5ffz29A9SJmZmWzfvp3IyEj7PLPZTGRkJNHR0XkuEx0dnWs8QMeOHW84/kbS0tJ44oknmD59Or6+vrccn5GRQUpKSq5JRESkOAR6V2TJM+HUqVqRU5eu0u2jaPac1udQUTK0IJ07d46cnBx8fHxyzffx8SEhISHPZRISEm5r/I288MILRERE8Oijj+Zr/KRJk/Dw8LBP/v7+t7U9ERGRO+Hn6criweE0ru7OuSuZ9JgVzfbjF4yOVWYZfg6SEVasWMF3333H1KlT873MmDFjSE5Otk8nTuihgiIiUry8KznzxaC2tKpdmZT0bJ78eAu/HDxndKwyydCC5O3tjcViITExMdf8xMTEGx728vX1va3xefnuu+84fPgwnp6eODg44ODgAEDXrl2555578lzG2dkZd3f3XJOIiEhx83B15NP+bfi/+t5czcrh6blbWbPr9o6iyK0ZWpCcnJxo2bIl69evt8+zWq2sX7+e8PDwPJcJDw/PNR5g7dq1Nxyfl9GjR/Prr78SFxdnnwDee+895syZc/tvREREpBhVcHLg476teKipL5k5VoYuiOHL7SeNjlWmOBgdYOTIkfTt25dWrVrRpk0bpk6dSmpqKv369QOgT58+1KhRg0mTJgEwYsQI7r77bqZMmULnzp1ZuHAh27ZtY9asWfZ1Xrhwgfj4eE6fPg3A/v37gWt7n/44Xa9WrVoEBgYW9VsWERG5Y84OFj7o2ZwxX+1kyfaTvLhkB5fTs3iqnT7HCoPhBal79+6cPXuWcePGkZCQQGhoKGvWrLGfiB0fH4/Z/L8dXRERESxYsIBXX32VsWPHUr9+fZYvX07Tpk3tY1asWGEvWAA9evQAYPz48UyYMKF43piIiEgRc7CYmdy1GW4ujvx7w1EmfL2Hy+nZDLuvnu7xd4cMvw9SaaX7IImISElhs9n41/qDTF13EIBeYbX4+yNNcLCUy2uxbqpU3AdJRERE7pzJZOL5yAaM79IYkwnmb45nwKfbuJKhh9wWlAqSiIhIGdGvXSAzn2yJi6OZH/af5bEZGzmTrEeTFIQKkoiISBnSsYkviwaF413JmX0Jl4mavoHdp5ONjlXqqCCJiIiUMSH+nix7NoL61SqRmJLB4zOj+X5f3g+Bl7ypIImIiJRB/lUqsHRIBO3reZOWmUP/eVv5LPqY0bFKDRUkERGRMsrD1ZE5/VrTrVVNrDZ47T+7eWPlHnKsuoD9VlSQREREyjDH3+6VNKpjQwA+/uUoz87fztXMHIOTlWwqSCIiImWcyWRi6L31+FePUJwsZv67O5Ees6JJupxudLQSSwVJRESknHg0tAbzB4ZRuYIjO04m85fpGzmQeNnoWCWSCpKIiEg50jqgCl89245A74qcunSVrjM2suHQOaNjlTgqSCIiIuVMoHdFvhoSQeuAylxOz6bvv7eweNsJo2OVKCpIIiIi5VDlik581j+MR0L8yLbaeGnpr7zz3/3oEa3XqCCJiIiUUy6OFv7VI5Th99UDYNr3hxixMI70LF3hpoIkIiJSjplMJl7s0JC3H2uGg9nEih2n6f3JZi6kZhodzVAqSCIiIkK3Vv7Me7oNbi4ObD12kb9+uIGj51KNjmUYFSQREREBoF09b74aEkENT1eOnU/jLx9uYOuxC0bHMoQKkoiIiNjV93Fj+dB2hNT04FJaFr1mb+Y/caeMjlXsVJBEREQkl6puziwcFE7HJj5k5lgZsTCOad8dLFdXuKkgiYiIyJ+4Oln4sFdLBv5fIADvfHuAl7/8lawcq8HJiocKkoiIiOTJYjbxSufGTHy0CWYTLN52kqfmbCH5apbR0YqcCpKIiIjcVO/wAD7u24oKThY2HDrPYzM2cuJCmtGxipQKkoiIiNzSfUE+LHkmHB93Zw4mXeEvH25kx4lLRscqMipIIiIiki9N/DxYPrQdjaq7c+5KBt1nRbNmV4LRsYqECpKIiIjkW3UPV5Y8E849DauSnmVlyPztfPzzkTJ3hZsKkoiIiNyWSs4OfNynFU+2rYXNBm+s2su4/+wmuwxd4aaCJCIiIrfNwWJm4qNNeaVTI0wm+GzTcQZ+uo3UjGyjoxUKFSQREREpEJPJxMC76vDhEy1wdjDz/f6zPD4zmoTkdKOj3TEVJBEREbkjDwVXZ+GgtnhXcmLPmRSipm9gz+kUo2PdERUkERERuWPNa1Vm2bPtqFetEgkp6Tw+cyPf708yOlaBqSCJiIhIofCvUoEvn4kgvI4XqZk5DJi3jc83HTc6VoGoIImIiEih8ajgyLyn2/BYy5rkWG28unwXb67ag9Vaum4DoIIkIiIihcrJwcw/H2vGiw80AGD2z0d5dn4MVzNzDE6WfypIIiIiUuhMJhPD76/P1O6hOFnMrNmdQI/Zmzh7OcPoaPmigiQiIiJFJqp5DT7r3wbPCo7sOHGJv3y4gUNJl42OdUsqSCIiIlKkwup48dWQCGp7VeDkxav89cONbDx8zuhYN6WCJCIiIkWuTtVKLHu2HS1rVyYlPZs+n2xh6faTRse6IRUkERERKRZVKjoxf0AYDzerTrbVxt+W7ODdb/eXyAfdqiCJiIhIsXFxtPB+j+YMvbcuAO9/d4jnF8WRkV2yrnBTQRIREZFiZTabGNUxiMldg7GYTfwn7jS9P97CxdRMo6PZqSCJiIiIIbq3rsXcfq1xc3Zgy7EL/HXGRo6dSzU6FqCCJCIiIgb6v/pVWTokghqerhw9l8pfPtzA9uMXjI6lgiQiIiLGaujrxrJnIwiu4cHFtCx6zt7M1ztOG5pJBUlEREQMV83dhUWD2/JAYx8ys60M/yKWT345algeFSQREREpESo4OTDzyZY83S4QB7OJRr5uhmUx2UrizQdKgZSUFDw8PEhOTsbd3d3oOCIiImXKoaQr1KtWqdDXm9/Pb+1BEhERkRKnKMrR7VBBEhEREbmOCpKIiIjIdVSQRERERK6jgiQiIiJyHRUkERERkeuoIImIiIhcp0QUpOnTpxMQEICLiwthYWFs2bLlpuOXLFlCUFAQLi4uBAcHs3r16lyvf/XVV3To0AEvLy9MJhNxcXG5Xr9w4QLDhw+nYcOGuLq6UqtWLZ577jmSk5ML+62JiIhIKWR4QVq0aBEjR45k/PjxxMTEEBISQseOHUlKSspz/MaNG+nZsyf9+/cnNjaWqKgooqKi2LVrl31Mamoq7du3Z/LkyXmu4/Tp05w+fZp33nmHXbt2MXfuXNasWUP//v2L5D2KiIhI6WL4nbTDwsJo3bo106ZNA8BqteLv78/w4cMZPXr0n8Z3796d1NRUVq5caZ/Xtm1bQkNDmTlzZq6xx44dIzAwkNjYWEJDQ2+aY8mSJTz55JOkpqbi4OBwy9y6k7aIiEjpUyrupJ2Zmcn27duJjIy0zzObzURGRhIdHZ3nMtHR0bnGA3Ts2PGG4/Pr9x/UjcpRRkYGKSkpuSYREREpmwwtSOfOnSMnJwcfH59c8318fEhISMhzmYSEhNsan98cEydOZNCgQTccM2nSJDw8POyTv79/gbcnIiIiJZvh5yAZLSUlhc6dO9O4cWMmTJhww3FjxowhOTnZPp04caL4QoqIiEixuvXJNkXI29sbi8VCYmJirvmJiYn4+vrmuYyvr+9tjb+Zy5cv8+CDD+Lm5sayZctwdHS84VhnZ2ecnZ1vexsiIiJS+hhakJycnGjZsiXr168nKioKuHaS9vr16xk2bFiey4SHh7N+/Xqef/55+7y1a9cSHh5+W9tOSUmhY8eOODs7s2LFClxcXG5r+d/Pbde5SCIiIqXH75/bt7xGzWawhQsX2pydnW1z58617dmzxzZo0CCbp6enLSEhwWaz2Wy9e/e2jR492j5+w4YNNgcHB9s777xj27t3r238+PE2R0dH286dO+1jzp8/b4uNjbWtWrXKBtgWLlxoi42NtZ05c8Zms9lsycnJtrCwMFtwcLDt0KFDtjNnztin7OzsfOU+ceKEDdCkSZMmTZo0lcLpxIkTN/2cN3QPEly7bP/s2bOMGzeOhIQEQkNDWbNmjf1E7Pj4eMzm/50qFRERwYIFC3j11VcZO3Ys9evXZ/ny5TRt2tQ+ZsWKFfTr18/+fY8ePQAYP348EyZMICYmhs2bNwNQr169XHmOHj1KQEDALXP7+flx4sQJ3NzcMJlMBX7/ZVlKSgr+/v6cOHFCt0IoAfT7KFn0+yhZ9PsoWYry92Gz2bh8+TJ+fn43HWf4fZCk7NK9okoW/T5KFv0+Shb9PkqWkvD7KPdXsYmIiIhcTwVJRERE5DoqSFJknJ2dGT9+vG6PUELo91Gy6PdRsuj3UbKUhN+HzkESERERuY72IImIiIhcRwVJRERE5DoqSCIiIiLXUUESERERuY4KkhSqSZMm0bp1a9zc3KhWrRpRUVHs37/f6Fjym3/84x+YTKZczzKU4nfq1CmefPJJvLy8cHV1JTg4mG3bthkdq1zKycnhtddeIzAwEFdXV+rWrcvEiRNv/ZwuKRQ//fQTXbp0wc/PD5PJxPLly3O9brPZGDduHNWrV8fV1ZXIyEgOHjxYLNlUkKRQ/fjjjwwdOpRNmzaxdu1asrKy6NChA6mpqUZHK/e2bt3KRx99RLNmzYyOUq5dvHiRdu3a4ejoyDfffMOePXuYMmUKlStXNjpauTR58mRmzJjBtGnT2Lt3L5MnT+btt9/mgw8+MDpauZCamkpISAjTp0/P8/W3336b999/n5kzZ7J582YqVqxIx44dSU9PL/JsusxfitTZs2epVq0aP/74I3fddZfRccqtK1eu0KJFCz788EPeeOMNQkNDmTp1qtGxyqXRo0ezYcMGfv75Z6OjCPDwww/j4+PDJ598Yp/XtWtXXF1d+fzzzw1MVv6YTCaWLVtGVFQUcG3vkZ+fHy+++CJ/+9vfAEhOTsbHx4e5c+fan7NaVLQHSYpUcnIyAFWqVDE4Sfk2dOhQOnfuTGRkpNFRyr0VK1bQqlUrHn/8capVq0bz5s2ZPXu20bHKrYiICNavX8+BAwcA2LFjB7/88gsPPfSQwcnk6NGjJCQk5Pq75eHhQVhYGNHR0UW+fYci34KUW1arleeff5527drRtGlTo+OUWwsXLiQmJoatW7caHUWAI0eOMGPGDEaOHMnYsWPZunUrzz33HE5OTvTt29foeOXO6NGjSUlJISgoCIvFQk5ODm+++Sa9evUyOlq5l5CQAICPj0+u+T4+PvbXipIKkhSZoUOHsmvXLn755Rejo5RbJ06cYMSIEaxduxYXFxej4wjX/uHQqlUr3nrrLQCaN2/Orl27mDlzpgqSARYvXsz8+fNZsGABTZo0IS4ujueffx4/Pz/9Pso5HWKTIjFs2DBWrlzJ999/T82aNY2OU25t376dpKQkWrRogYODAw4ODvz444+8//77ODg4kJOTY3TEcqd69eo0btw417xGjRoRHx9vUKLybdSoUYwePZoePXoQHBxM7969eeGFF5g0aZLR0co9X19fABITE3PNT0xMtL9WlFSQpFDZbDaGDRvGsmXL+O677wgMDDQ6Url2//33s3PnTuLi4uxTq1at6NWrF3FxcVgsFqMjljvt2rX7060vDhw4QO3atQ1KVL6lpaVhNuf+KLRYLFitVoMSye8CAwPx9fVl/fr19nkpKSls3ryZ8PDwIt++DrFJoRo6dCgLFizgP//5D25ubvbjxB4eHri6uhqcrvxxc3P70/lfFStWxMvLS+eFGeSFF14gIiKCt956i27durFlyxZmzZrFrFmzjI5WLnXp0oU333yTWrVq0aRJE2JjY3n33Xd5+umnjY5WLly5coVDhw7Zvz969ChxcXFUqVKFWrVq8fzzz/PGG29Qv359AgMDee211/Dz87Nf6VakbCKFCMhzmjNnjtHR5Dd33323bcSIEUbHKNe+/vprW9OmTW3Ozs62oKAg26xZs4yOVG6lpKTYRowYYatVq5bNxcXFVqdOHdsrr7xiy8jIMDpaufD999/n+ZnRt29fm81ms1mtVttrr71m8/HxsTk7O9vuv/9+2/79+4slm+6DJCIiInIdnYMkIiIich0VJBEREZHrqCCJiIiIXEcFSUREROQ6KkgiIiIi11FBEhEREbmOCpKIiIjIdVSQRERERK6jgiQiUkh++OEHTCYTly5dMjqKiNwhFSQRERGR66ggiYiIiFxHBUlEygyr1cqkSZMIDAzE1dWVkJAQli5dCvzv8NeqVato1qwZLi4utG3bll27duVax5dffkmTJk1wdnYmICCAKVOm5Ho9IyODl19+GX9/f5ydnalXrx6ffPJJrjHbt2+nVatWVKhQgYiICPbv31+0b1xECp0KkoiUGZMmTeLTTz9l5syZ7N69mxdeeIEnn3ySH3/80T5m1KhRTJkyha1bt1K1alW6dOlCVlYWcK3YdOvWjR49erBz504mTJjAa6+9xty5c+3L9+nThy+++IL333+fvXv38tFHH1GpUqVcOV555RWmTJnCtm3bcHBw4Omnny6W9y8ihcdks9lsRocQEblTGRkZVKlShXXr1hEeHm6fP2DAANLS0hg0aBD33nsvCxcupHv37gBcuHCBmjVrMnfuXLp160avXr04e/Ys3377rX35l156iVWrVrF7924OHDhAw4YNWbt2LZGRkX/K8MMPP3Dvvfeybt067r//fgBWr15N586duXr1Ki4uLkX8UxCRwqI9SCJSJhw6dIi0tDQeeOABKlWqZJ8+/fRTDh8+bB/3x/JUpUoVGjZsyN69ewHYu3cv7dq1y7Xedu3acfDgQXJycoiLi8NisXD33XffNEuzZs3sX1evXh2ApKSkO36PIlJ8HIwOICJSGK5cuQLAqlWrqFGjRq7XnJ2dc5WkgnJ1dc3XOEdHR/vXJpMJuHZ+lIiUHtqDJCJlQuPGjXF2diY+Pp569erlmvz9/e3jNm3aZP/64sWLHDhwgEaNGgHQqFEjNmzYkGu9GzZsoEGDBlgsFoKDg7FarbnOaRKRskl7kESkTHBzc+Nvf/sbL7zwAlarlfbt25OcnMyGDRtwd3endu3aALz++ut4eXnh4+PDK6+8gre3N1FRUQC8+OKLtG7dmokTJ9K9e3eio6OZNm0aH374IQABAQH07duXp59+mvfff5+QkBCOHz9OUlIS3bp1M+qti0gRUEESkTJj4sSJVK1alUmTJnHkyBE8PT1p0aIFY8eOtR/i+sc//sGIESM4ePAgoaGhfP311zg5OQHQokULFi9ezLhx45g4cSLVq1fn9ddf56mnnrJvY8aMGYwdO5Znn32W8+fPU6tWLcaOHWvE2xWRIqSr2ESkXPj9CrOLFy/i6elpdBwRKeF0DpKIiIjIdVSQRERERK6jQ2wiIiIi19EeJBEREZHrqCCJiIiIXEcFSUREROQ6KkgiIiIi11FBEhEREbmOCpKIiIjIdVSQRERERK6jgiQiIiJynf8Ha+lD5ew5GNkAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjcAAAGwCAYAAABVdURTAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAABo2klEQVR4nO3dd1yVdf/H8ddhDwFFBBy490BQnGmWWlZmOXJVanZn9UsrtaVpmlnOLOu2Mr01bytHaaVlt6WYIzM3bnHlFsTFlHXO9fvjKEpqAgIX4/18PHh0ne+5xochvPte3+v7tRiGYSAiIiJSRDiYXYCIiIhIblK4ERERkSJF4UZERESKFIUbERERKVIUbkRERKRIUbgRERGRIkXhRkRERIoUJ7MLyG82m43Tp0/j5eWFxWIxuxwRERHJAsMwiI+Pp1y5cjg4/HPfTLELN6dPnyYoKMjsMkRERCQHTpw4QYUKFf5xn2IXbry8vAD7F8fb29vkakRERCQr4uLiCAoKyvg7/k+KXbi5eivK29tb4UZERKSQycqQEg0oFhERkSJF4UZERESKFIUbERERKVKK3ZibrLJaraSlpZldhhQjzs7OODo6ml2GiEihp3DzN4ZhEBUVxaVLl8wuRYqhkiVLEhgYqDmYRETugMLN31wNNv7+/nh4eOiPjOQLwzBISkri7NmzAJQtW9bkikRECi+Fm+tYrdaMYFO6dGmzy5Fixt3dHYCzZ8/i7++vW1QiIjmkAcXXuTrGxsPDw+RKpLi6+rOn8V4iIjmncHMTuhUlZtHPnojInVO4ERERkSJF4UZERESKFIUbKbLuvvtu5s2blyfnPnr0KBaLhYiIiCwfM336dDp16pQn9YiIyDUKN1IkLV26lOjoaHr16pXRZrFY+OGHH3Ll/EFBQZw5c4b69etn+Zinn36abdu2sW7dulypQUSkQDq0EtJTTC1B4UbyjJlP/Hz88cf0798fB4fs/YinpqZmaT9HR0cCAwNxcsr6bAouLi48/vjjfPzxx9mqSUSk0Di4Er7uDnMehtRE08pQuLkNwzBISk035cMwjCzXuXz5clq1akXJkiUpXbo0Dz/8MIcPH860z8mTJ+nduze+vr54enoSFhbGxo0bM97/8ccfadKkCW5ubvj5+dGlS5eM927W61GyZEnmzJkDXLtNs3DhQtq0aYObmxtff/0158+fp3fv3pQvXx4PDw8aNGjA/PnzM53HZrMxadIkqlevjqurKxUrVuS9994DoG3btgwaNCjT/jExMbi4uBAeHn7Tr0VMTAyrVq3KdAuocuXKAHTp0gWLxZLx+u233yYkJIT//Oc/VKlSBTc3tyx9Pf9+W2r16tVYLBbCw8MJCwvDw8ODli1bEhkZmam2Tp06sXTpUi5fvnzT2kVECq1zB2HR02DYwL82OJs3rYom8buNy2lW6o76xZRr732nAx4uWfsWJSYmMnToUIKDg0lISGDUqFF06dKFiIgIHBwcSEhIoE2bNpQvX56lS5cSGBjItm3bsNlsACxbtowuXbowYsQI5s6dS2pqKj///HO2ax42bBhTpkwhNDQUNzc3kpOTady4MW+88Qbe3t4sW7aMPn36UK1aNZo2bQrA8OHDmTlzJh9++CGtWrXizJkz7N+/H4BnnnmGQYMGMWXKFFxdXQH46quvKF++PG3btr1pDb///jseHh7UqVMno23z5s34+/vzxRdf8MADD2SaIO/QoUMsXryY7777LqP9dl/PWxkxYgRTpkyhTJkyPP/88zz99NOsX78+4/2wsDDS09PZuHEj99xzT7a/viIiBdLlSzC/F6TEQsUW8NAUMHFqC4WbIqJbt26ZXs+ePZsyZcqwd+9e6tevz7x584iJiWHz5s34+voCUL169Yz933vvPXr16sWYMWMy2ho2bJjtOgYPHkzXrl0ztb366qsZ2y+++CK//PIL33zzDU2bNiU+Pp6PPvqIadOm0a9fPwCqVatGq1atAOjatSuDBg1iyZIl9OjRA4A5c+bw1FNP3XJOmGPHjhEQEJAphJQpUwa4tnbT9VJTU5k7d27GPnD7r+etvPfee7Rp0wawB72OHTuSnJyc0SPk4eGBj48Px44du+U5REQKFZsVFv8Lzh8C7wrQ40twcjG1JIWb23B3dmTvOx1Mu3ZWHTx4kFGjRrFx40bOnTuX0SNz/Phx6tevT0REBKGhoRnB5u8iIiIYMGDAHdccFhaW6bXVamXcuHF88803nDp1itTUVFJSUjJm4t23bx8pKSm0a9fupudzc3OjT58+zJ49mx49erBt2zZ2797N0qVLb1nD5cuXM8JEVlSqVClTsIHbfz1vJTg4OGP76vpQZ8+epWLFihnt7u7uJCUlZbk+EZECbeXb9kHETu7Qex6UKHPbQ/Kaws1tWCyWLN8aMlOnTp2oVKkSM2fOpFy5cthsNurXr58xQPbqukW3crv3LRbLDWOAbjZg2NPTM9PryZMn89FHHzF16lQaNGiAp6cngwcPznJdYL81FRISwsmTJ/niiy9o27YtlSpVuuX+fn5+XLx48bbnvVXNcPuv5604OztnbF/tWboajK66cOHCDWFKRKRQ2rEA/rjykETnT6Fs9nv884IGFBcB58+fJzIykpEjR9KuXTvq1Klzwx/34OBgIiIiuHDhwk3PERwcfMsBumC/rXPmzJmM1wcPHsxS78P69et59NFHefLJJ2nYsCFVq1blwIEDGe/XqFEDd3f3f7x2gwYNCAsLY+bMmcybN4+nn376H68ZGhpKVFTUDV8DZ2dnrFbrbWvOytczpw4fPkxycjKhoaG5cj4REdOc3ApLX7Jvt34V6nf95/3zkcJNEVCqVClKly7NjBkzOHToEKtWrWLo0KGZ9unduzeBgYF07tyZ9evXc+TIERYvXsyGDRsAGD16NPPnz2f06NHs27ePXbt2MXHixIzj27Zty7Rp09i+fTtbtmzh+eefz9RLcSs1atRgxYoV/PHHH+zbt4/nnnuO6OjojPfd3Nx44403eP3115k7dy6HDx/mzz//ZNasWZnO88wzzzBhwgQMw8j0FNfNhIaG4ufnl2kgL9ifmAoPD79p8LleVr6eObVu3TqqVq1KtWrVcuV8IiKmiDsDC58AawrUegjuHWF2RZko3BQBDg4OLFiwgK1bt1K/fn2GDBnC5MmTM+3j4uLCr7/+ir+/Pw899BANGjRgwoQJGU8H3XPPPXz77bcsXbqUkJAQ2rZty6ZNmzKOnzJlCkFBQbRu3ZrHH3+cV199NUurp48cOZJGjRrRoUMH7rnnnoyAdb233nqLV155hVGjRlGnTh169uzJ2bNnM+3Tu3dvnJyc6N27923H0zg6OtK/f3++/vrrTO1TpkxhxYoVBAUF/WPPSVa+njk1f/78XBnbJCJimrRke7CJPwNl6kCXzyGbc4rlNYuRnclUioC4uDh8fHyIjY3F29s703vJycn89ddfmeY7kYLh6NGjVKtWjc2bN9OoUaPb7h8VFUW9evXYtm3bP47PyU979uyhbdu2HDhwAB8fn5vuo59BESnQDAN++D/YMR/cS8GAVeBbNV8u/U9/v/+uYEUtkb9JS0sjKiqKkSNH0rx58ywFG4DAwEBmzZrF8ePH87jCrDtz5gxz5869ZbARESnwNnxiDzYWR+g+J9+CTXYV/MeApFhbv3499957LzVr1mTRokXZOvbvt7/M1r59e7NLEBHJuUMrYcVb9u0HxkPVe0wt558o3EiBds8992RrGQoREckD5w7Bt1eWVgjtA02fNbuif6TbUiIiInJrybHXllYIagYdzV1aISsUbkREROTmbFZY9C84fxC8y0PPr8DJ1eyqbkvhRkRERG4ufAwcWmFfWqHXPCjhb3ZFWaJwIyIiIjfa+Q2s/8i+3fkTKBdiajnZoXAjIiIimZ3aCksG2bdbvwL1u5lbTzYp3EiRdffddzNv3rx8v+7y5csJCQm5YcFMEZFCIT4KFlxZWqHmg3DvSLMryjaFGymSli5dSnR0NL169cpos1gs/PDDD7l6ncqVKzN16tRMbQ888ADOzs43LP8gIlLgpSXbg038GShTG7rOKHBLK2RF4atYCo20tDTTrv3xxx/Tv39/HEz6R/nUU0/x8ccfm3JtEZEcMQz4aQic2gJuJe0DiN3+eZmDgkrhpohYvnw5rVq1omTJkpQuXZqHH36Yw4cPZ9rn5MmT9O7dG19fXzw9PQkLC2Pjxo0Z7//44480adIENzc3/Pz8Mq2+fbNej5IlSzJnzhzAvvaTxWJh4cKFtGnTBjc3N77++mvOnz9P7969KV++PB4eHjRo0ID58+dnOo/NZmPSpElUr14dV1dXKlasyHvvvQfYVyMfNGhQpv1jYmJwcXEhPDz8pl+LmJgYVq1aRadOnTLaKleuDECXLl2wWCwZrwGWLFlCo0aNcHNzo2rVqowZM4b09HQADMPg7bffpmLFiri6ulKuXDleeuklwD7B4LFjxxgyZAgWiwXLdfM+dOrUiS1bttzwPRARKbD+/BR2zLu2tELpamZXlGOaofh2DAPSksy5trNHlidKSkxMZOjQoQQHB5OQkMCoUaPo0qULERERODg4kJCQQJs2bShfvjxLly4lMDCQbdu2ZYwLWbZsGV26dGHEiBHMnTuX1NRUfv7552yXPGzYMKZMmUJoaChubm4kJyfTuHFj3njjDby9vVm2bBl9+vShWrVqNG3aFIDhw4czc+ZMPvzwQ1q1asWZM2fYv38/AM888wyDBg1iypQpuLra51b46quvKF++PG3btr1pDb///jseHh7UqVMno23z5s34+/vzxRdf8MADD2Sshr5u3Tr69u3Lxx9/TOvWrTl8+DDPPmufeXP06NEsXryYDz/8kAULFlCvXj2ioqLYsWMHAN999x0NGzbk2WefvWGl74oVKxIQEMC6deuoVq3w/oIQkWLiUDj8emVsTYf3oNq95tZzhxRubictCcaVM+fab54GF88s7dqtW+aR7LNnz6ZMmTLs3buX+vXrM2/ePGJiYti8eTO+vr4AVK9ePWP/9957j169ejFmzJiMtoYNG2a75MGDB9O1a9dMba+++mrG9osvvsgvv/zCN998Q9OmTYmPj+ejjz5i2rRp9OvXD4Bq1arRqlUrALp27cqgQYNYsmQJPXr0AGDOnDk89dRTmXpKrnfs2DECAgIy3ZIqU6YMYO9tCgwMzGgfM2YMw4YNy7h21apVGTt2LK+//jqjR4/m+PHjBAYG0r59e5ydnalYsWJGKPP19cXR0REvL69M57yqXLlyHDt2LHtfQBGR/Hb+MCzqf2VphSeh2fNmV3THdFuqiDh48CC9e/ematWqeHt7Z9x2uboqdkREBKGhoRnB5u8iIiJo167dHdcRFhaW6bXVamXs2LE0aNAAX19fSpQowS+//JJR1759+0hJSbnltd3c3OjTpw+zZ88GYNu2bezevZunnnrqljVcvnwZNze3LNW7Y8cO3nnnHUqUKJHxMWDAAM6cOUNSUhLdu3fn8uXLVK1alQEDBvD9999n3LK6HXd3d5KSTOr1ExHJiqtLKyRfXVrhgztaWiE5zcoz/93C+kPncrHI7FPPze04e9h7UMy6dhZ16tSJSpUqMXPmTMqVK4fNZqN+/fqkpqYC9j+0/+R271sslhsWsLzZgGFPz8w9TZMnT+ajjz5i6tSpNGjQAE9PTwYPHpzlusB+ayokJISTJ0/yxRdf0LZtWypVqnTL/f38/Lh48eJtzwuQkJDAmDFjbuhtAnuwCgoKIjIykpUrV7JixQpeeOEFJk+ezJo1a3B2dv7Hc1+4cCGjx0hEpMCxWWHxADh3wL60Qo8v72hpheQ0K89+uZW1B2LYfvwi6964Fw8Xc2KGws3tWCxZvjVklvPnzxMZGcnMmTNp3bo1YB93cr3g4GD+85//cOHChZv23gQHBxMeHk7//v1veo0yZcpw5syZjNcHDx7MUq/E+vXrefTRR3nyyScB++DhAwcOULduXQBq1KiBu7s74eHhPPPMMzc9R4MGDQgLC2PmzJnMmzePadOm/eM1Q0NDiYqK4uLFi5QqVSqj3dnZGavVmmnfRo0aERkZmekW3d+5u7vTqVMnOnXqxMCBA6lduza7du2iUaNGuLi43HBOgOTkZA4fPkxoaOg/1ioiYprwd+DgL+DkBr2+Bq+AHJ8qJd3KC19vY+2BGNydHfn0iUamBRsoALelPvnkEypXroybmxvNmjVj06ZN/7j/pUuXGDhwIGXLlsXV1ZWaNWvmaOBrUVKqVClKly7NjBkzOHToEKtWrWLo0KGZ9unduzeBgYF07tyZ9evXc+TIERYvXsyGDRsA++DZ+fPnM3r0aPbt28euXbuYOHFixvFt27Zl2rRpbN++nS1btvD888/ftucC7OFlxYoV/PHHH+zbt4/nnnuO6OjojPfd3Nx44403eP3115k7dy6HDx/mzz//ZNasWZnO88wzzzBhwgQMw8j0FNfNhIaG4ufnx/r16zO1V65cmfDw8IzgAzBq1Cjmzp3LmDFj2LNnD/v27WPBggWMHGkfWDdnzhxmzZrF7t27OXLkCF999RXu7u4ZPUeVK1dm7dq1nDp1inPnrnXD/vnnn7i6utKiRYvbfo1ERPLdzm9h/VT79qOfQLmc/49YmtXGoHnbWbX/LK5ODszqF0azqqVzp86cMky0YMECw8XFxZg9e7axZ88eY8CAAUbJkiWN6Ojom+6fkpJihIWFGQ899JDx+++/G3/99ZexevVqIyIiIsvXjI2NNQAjNjb2hvcuX75s7N2717h8+XKOPyezrFixwqhTp47h6upqBAcHG6tXrzYA4/vvv8/Y5+jRo0a3bt0Mb29vw8PDwwgLCzM2btyY8f7ixYuNkJAQw8XFxfDz8zO6du2a8d6pU6eM+++/3/D09DRq1Khh/Pzzz4aPj4/xxRdfGIZhGH/99ZcBGNu3b89U1/nz541HH33UKFGihOHv72+MHDnS6Nu3r/Hoo49m7GO1Wo13333XqFSpkuHs7GxUrFjRGDduXKbzxMfHGx4eHsYLL7yQpa/H66+/bvTq1StT29KlS43q1asbTk5ORqVKlTLaly9fbrRs2dJwd3c3vL29jaZNmxozZswwDMMwvv/+e6NZs2aGt7e34enpaTRv3txYuXJlxrEbNmwwgoODDVdXV+P6f07PPvus8dxzz2Wp1usV5p9BESkkTm41jLH+hjHa2zBWjL6jU6WmW43nv9xiVHrjJ6PGiJ+NtQfO5k6NN/FPf7//zmIYfxtIkY+aNWtGkyZNMm4z2Gw2goKCePHFFxk2bNgN+0+fPp3Jkyezf//+LPUa3ExcXBw+Pj7Exsbi7Z15cqLk5GT++usvqlSpkuUBqZI/jh49SrVq1di8eTONGjW67f5RUVHUq1ePbdu2/eP4nLxw7tw5atWqxZYtW6hSpUq2jtXPoIjkqfgomHEvxJ+Gmg/YJ+pzcMzRqdKtNgYvjOCnnWdwcXTg876NubdW3q0a/k9/v//OtNtSqampbN26lfbt218rxsGB9u3bZ9wq+bulS5fSokULBg4cSEBAAPXr12fcuHE3HfNwVUpKCnFxcZk+pPBIS0sjKiqKkSNH0rx58ywFG4DAwEBmzZqV8VRWfjp69CiffvpptoONiEieSk+BhX3swcavFnSdmeNgY7UZvPrtDn7aeQZnRwufPtEoT4NNdpk22ufcuXNYrVYCAjIPYAoICMiYwO3vjhw5wqpVq3jiiSf4+eefOXToEC+88AJpaWmMHj36pseMHz8+09wtUrisX7+ee++9l5o1a7Jo0aJsHdu5c+e8Keo2wsLCbngkXkTEVFeXVji5Cdx8oPf8HC+tYLMZvLF4Jz9EnMbRwcK/ezeifd2cD0bOC4XqaSmbzYa/vz8zZszA0dGRxo0bc+rUKSZPnnzLcDN8+PBMg2vj4uIICgrKr5LlDt1zzz03PIIuIiLZ9OdnEPE1WBzuaGkFm83gze93sWjrSRwdLHzcK5QH6t84ianZTAs3fn5+ODo6ZnpyBiA6Ovqms70ClC1bFmdn54yp8wHq1KlDVFQUqampuLi43HCMq6trxrT9IiIixc7hVfDrCPv2/e9BtZsvXXM7hmEwauluFmw+gYMFPujRkI7BZXOx0Nxj2pgbFxcXGjdunGnxQ5vNRnh4+C0fn73rrrs4dOhQxnpIAAcOHKBs2bI3DTY5pZ4CMYt+9kQkV50/DN9eWVoh5Alo/n85Oo1hGIz5cS9f/XkciwXe796QR0PK53KxucfUeW6GDh3KzJkz+e9//8u+ffv4v//7PxITEzMmkuvbty/Dhw/P2P///u//uHDhAi+//DIHDhxg2bJljBs3joEDB+ZKPVefwNKU+WKWqz97OX0aUEQkQ3IczO8NyZegQlN4+MMcLa1gGAbvLdvHnD+OAjCxWzBdG1XI3Vpzmaljbnr27ElMTAyjRo0iKiqKkJAQli9fnjHI+Pjx45kWPwwKCuKXX35hyJAhBAcHU758eV5++WXeeOONXKnH0dGRkiVLcvbsWQA8PDxuuTijSG4yDIOkpCTOnj1LyZIlM916FRHJNpsVvhsA5yLBqxz0/CpHSysYhsHE5ZH85/e/ABjftQE9wgr+uFVT57kxw+2ekzcMg6ioKC5dupT/xUmxd3XVcoVqEbkjK8fA7x/Yl1bo/z8on7VpNP5uyq+R/HvVIQDGPlqPPi0q52KR2ZOdeW4K1dNS+cFisVC2bFn8/f1vujCkSF75+2B5EZEc2bXIHmwAHpmW42Dz0cqDGcFmdKe6pgab7FK4uQVHR0f9oRERkcLl9HZYcmUc6l2DIbh7jk7zyW+H+HDlAQBGPFSH/ncVrklJTV84U0RERHJBfDQseALSk6FGB2g3KkenmbH2MJN/iQTg9QdqMeDuqrlZZb5QuBERESns0lNg4ZMQdwr8akK3nC2tMOv3vxj3s32VgKH31eSFe6rndqX5QuFGRESkMDMMWDb0uqUVFtj/m03//eMoY3/aC8BLbavzUrsauV1pvlG4ERERKcw2fg7bv7IvrfDYFzlaWuHrjccYvXQPAP93TzWG3Fczt6vMVwo3IiIihdXh3+CXN+3b978L1dtl+xQLNx9nxPe7ARjQugqvd6hV6KejULgREREpjM4fhm+fAsMKDR+H5i9k+xSLtp5k2He7AOh/V2XefKhOoQ82oHAjIiJS+CTHwYLH7UsrlA/L0dIKSyJO8dqiHRgG9GleiVEP1y0SwQYUbkRERAoXmw2+exZi9oNXWej1NTi7ZesUP+08zZCFERgG9G4axJhH6hWZYAMKNyIiIoXLb+/Cgf+Bo6s92HgFZuvw5bvP8PKCCGwGdG9cgfc6N8DBoegEG1C4ERERKTx2L4Z1U+zbj06D8o2zdfiKvdEMmrcdq82ga2h5JnQLLnLBBhRuRERECofTEfDD1aUVXobgHtk6/Lf9Z3nh662k2ww6NSzH5O4NcSyCwQYUbkRERAq+hLP2AcTpl6HG/dBudLYOX3sghue+2kqa1eChBoF82KPoBhtQuBERESnYrl9aoXQN6PafbC2tsP7QOQbM3UJquo0O9QL4qFcoTo5F+89/0f7sRERECjPDgGWvwImN4Jr9pRX+PHKef/13MynpNtrX8effvRvhXMSDDSjciIiIFFybZsD2L+1LK3SfDX5ZX8hy89ELPD1nM8lpNu6pVYZPnmiEi1Px+LNfPD5LERGRwubIalg+3L593ztQvX2WD912/CJPzd5EUqqV1jX8mP5kY1ydsr9KeGGlcCMiIlLQXDgC3/S7srRCb2gxKMuH7jhxiX6zNpGYaqVF1dLM6BOGm3PxCTagcCMiIlKwpMTD/OuXVpia5aUVdp+Kpc+sjcSnpNO0ii+zngrD3aV4BRtQuBERESk4MpZW2AclAqHnV1leWmHv6TienLWRuOR0GlcqxeynmuDh4pTHBRdMCjciIiIFxW/vQeTPV5ZWmAfeZbN0WGRUPE/O2silpDRCgkoyp38TSrgWz2ADCjciIiIFw+7vYN379u1H/g0Vsra0wqGz8Tzxnz+5kJhKcAUf/vt0U7zcnPOw0IJP4UZERMRsB36BH16wb7d8ERr2zNJhh2MS6D1zI+cSUqlb1pu5TzfFx714BxuA4ttnJSIiYrbURPh1JGyZbX9d/T5oPyZLhx49l8jjM/8kJj6F2oFefP1MM0p6uORhsYWHwo2IiIgZTm6F7wbAhcP2180HQrtRWVpa4cSFJB6f+SfRcSnU8C/BV880o5Sngs1VCjciIiL5yZoO66bAmon2eWy8ykGXz6DqPVk6/OTFJHrN+JPTsclULePJ1wOa4VfCNW9rLmQUbkRERPLL+cPw/XNwcrP9df1u0HEKuJfK0uFnYi/z+MyNnLp0mSp+nswf0Bx/r6w9Kl6cKNyIiIjkNcOAbXPtyymkJdoXwew4BYK7Z/kU0XHJ9J7xJ8cvJFHR14N5A5oR4K1gczMKNyIiInkpIQZ+fMk+fw1A5dbQ+TMoGZTlU5yNT6b3zD85ej6J8iXdmTegGWV93POo4MJP4UZERCSvHPgFlgyExBhwdIG2b9nXiXLI+kws5xJSeGLmRo7EJFLOx40FzzanQimPPCy68FO4ERERyW2pifDLCNj6hf21f13oOhMC62frNBcSU3nyPxs5eDaBQG835j/bnCBfBZvbUbgRERHJTX9/xLvFIHuPTRbXiLrqUpI92OyPisffy5V5A5pRqbRnHhRc9CjciIiI5AZrun35hDWT7I94e5e3j62p2ibbp4q9nEafWZvYeyYOvxIuzBvQnKplSuRB0UWTwo2IiMidOn/Yvpr3qS321/Ufg47vZ/kR7+vFJ6fRb/Ymdp2KxdfTHmyq+yvYZIfCjYiISE4ZBmz775VHvJNy9Ij39RJS0nnqi81EnLhESQ9nvvpXM2oGeOVy0UWfwo2IiEhO5MIj3tdLSk3n6S82s/XYRbzdnPjqX82oW847FwsuPhRuREREsityOSwddO0R73aj7GtDZeMR7+vFJ6fx7NytbDp6AS9XJ778VzPql/fJ5aKLD4UbERGRrEpNhF/ehK1z7K9z+Ij39dYciGH44p2cjk2mhKsT//1XUxoGlcyVcosrhRsREZGsOLnlyiPeR+yvc/iI91WxSWm8u2wv3249CUCQrzsf9woltGL2ByFLZgo3IiIi/8SaDmsn2z/u8BHvq1bujebN73dxNj4FiwX6tajM6w/UwsNFf5Zzg76KIiIit3L+sL235tRW++s7eMQb4GJiKm//uIclEacBqOrnycTHgmlS2Te3KhYUbkRERG5kGPZxNb+8mSuPeAP8vOsMo5bs5lxCKg4WGHB3VYa0r4mbs2Pu1S2Awo2IiEhmCTH2J6EOLLe/vsNHvGPiUxi1ZDf/2x0FQM2AEkx6rCEhGjScZxRuREREror8HywZBEnn7vgRb8MwWBJxmrd/3MOlpDQcHSy8cE81BrWtjquTemvyksKNiIhISgL8OuK6R7zrQdcZOX7EOyo2mZE/7GLlvrMA1C3rzaTHgjV3TT5RuBERkeItFx/xNgyDb7eeZOxPe4lPTsfZ0cJLbWvw/D3VcHbM2QR/kn0KNyIiUjxZ02Dt+7n2iPfJi0kM/24X6w6eA6BhBR8mPdaQWoFaGyq/KdyIiEjxk4uPeNtsBl9vOs6En/eRmGrFxcmBV+6ryb9aVcFJvTWmULgREZHiwzBg6xfwy4hrj3g//AE0eCxHpzt2PpE3Fu/kzyMXAAirVIqJjwVTrUyJ3KxasknhRkREioeEs7D0xcyPeHeZDj4Vsn0qq83gv38cZfIvkVxOs+Lu7MjrD9Sib4vKODpYcrlwyS6FGxERKfpueMR7NDR/IUePeB+OSeD1RTvZeuwiAM2r+jKxWzCVSnvmdtWSQwXiZuAnn3xC5cqVcXNzo1mzZmzatOmW+86ZMweLxZLpw80tZ4uWiYhIEZeSAEtfgvm97MHGvx4M+A1aDsp2sEm32pi+5jAPfrSOrccu4uniyLud6zPvmeYKNgWM6T03CxcuZOjQoUyfPp1mzZoxdepUOnToQGRkJP7+/jc9xtvbm8jIyIzXFou6AEVE5G9ObIbvn73yiLcFWgzM8SPekVHxvL5oBztOxgLQuoYfE7oFU76key4XLbnB9HDzwQcfMGDAAPr37w/A9OnTWbZsGbNnz2bYsGE3PcZisRAYGJifZYqISGFhTbuyivf7Vx7xrgBdPoMqd2f7VGlWG5+tPsy/Vx0kzWrg5ebEWw/XpXvjCvof6wLM1HCTmprK1q1bGT58eEabg4MD7du3Z8OGDbc8LiEhgUqVKmGz2WjUqBHjxo2jXr16N903JSWFlJSUjNdxcXG59wmIiEjBcu6Q/RHv09vsrxt0h4feB/eS2T7V7lOxvLZoJ/vO2P9utK/jz3tdGhDgraEQBZ2p4ebcuXNYrVYCAgIytQcEBLB///6bHlOrVi1mz55NcHAwsbGxvP/++7Rs2ZI9e/ZQocKNI97Hjx/PmDFj8qR+EREpIAwDtsyGX0fe8SPeKelW/h1+iM/WHMZqMyjp4cyYR+rxSMNy6q0pJEy/LZVdLVq0oEWLFhmvW7ZsSZ06dfj8888ZO3bsDfsPHz6coUOHZryOi4sjKChnK7uKiEgBlHDW/iTUwV/sr+/gEe+IE5d47dsdHDybAMBDDQIZ80h9yni55mbFksdMDTd+fn44OjoSHR2dqT06OjrLY2qcnZ0JDQ3l0KFDN33f1dUVV1f9UIqIFDk2K+xYACtG3fEj3slpVj5ccYCZ645gM8CvhAvvPFqfhxqUzaPiJS+Z+ii4i4sLjRs3Jjw8PKPNZrMRHh6eqXfmn1itVnbt2kXZsvoBFBEpNg6Fw+d3w5IXrj3i/ezqHD3ivfnoBR78aB2fr7UHm84h5fh1SBsFm0LM9NtSQ4cOpV+/foSFhdG0aVOmTp1KYmJixtNTffv2pXz58owfPx6Ad955h+bNm1O9enUuXbrE5MmTOXbsGM8884yZn4aIiOSHqF32nprDq+yvXX3g7leg2fPglL1e+qTUdCYtj+S/G45iGODv5cp7XRpwX92A2x8sBZrp4aZnz57ExMQwatQooqKiCAkJYfny5RmDjI8fP47DdSn84sWLDBgwgKioKEqVKkXjxo35448/qFu3rlmfgoiI5LXYU7DqXdgxHzDAwRmaDoC7XwMP32yf7o9D53jju52cuHAZgB5hFRjRsS4+7s65XLiYwWIYhmF2EfkpLi4OHx8fYmNj8fb2NrscERH5J8lx8PuH8OenkJ5sb6vXFdqNAt8q2T5dfHIa4/+3n3kbjwNQvqQ747s24O6aZXKzaskD2fn7bXrPjYiIyA2sabB1DqweD0nn7W0VW8D970KFsBydcnXkWd78bhenY+0h6cnmFXnjgdp4uam3pqhRuBERkYLDMGD/T7DybTh/5SnY0tWh/Rio3RFyMM9MbFIaY5ftZdHWkwBU9PVgQrcGtKzml4uFS0GicCMiIgXDic32SfhO/Gl/7eEH9wyDxk+BY856V1bsjWbE97s4G5+CxQJPtazMax1q4eGiP39Fmb67IiJirvOHIXwM7F1if+3kbl/k8q6XwS1nYyMvJKby9tI9LN1xGoCqfp5MeiyYsMrZH3wshY/CjYiImCPpAqyZBJv/A7Y0wAKhT8C9I8C7XI5Pu2znGUYt2c35xFQcLDDg7qoMaV8TN2fH3KtdCjSFGxERyV9pybBxOqz7AFJi7W3V2sF970Bg/RyfNiY+hVFLdvO/3VEA1AwoweTHGtIwqGQuFC2FicKNiIjkD5sNdn0Lq8ZC7Al7W0ADuP8dqNY2x6c1DIMfIk4x5se9XEpKw8nBwgv3VGNg2+q4Oqm3pjhSuBERkbx3ZA2seAvO7LC/9i4PbUdCcE9wyHkAuZiYyqvf7iB8/1kA6pb1ZnL3YOqV88mNqqWQUrgREZG8E73XvlzCoRX21y5e0HqIfXFLZ/c7OrVhGAz9JoLfImNwdrTwcrsaPNemGs6Opi6bKAWAwo2IiOS++Cj47T3Y/hUYNnBwgrCnoc0b4Jk788t8u+Ukv0XG4OLowKL/a0FwhZK5cl4p/BRuREQk96QkwB8fwx//hrQke1udTtDubfCrnmuXOXXpMmN/2gvA0PtrKthIJgo3IiJy56zpsH0u/DYeEu3jX6jQFO4fCxWb5+qlDMNg2OKdxKek06hiSQa0rpqr55fCT+FGRERyzjDgwHJYMRrORdrbSlWB9m9D3UdztFzC7Xy98TjrDp7D1cmB97s3xNEh968hhZvCjYiI5MypbfDrW3Dsd/trd1/7mJqwp8HJJU8ueeJCEuN+3gfA6w/UpmqZEnlyHSncFG5ERCR7Lh6D8Hdg9yL7a0dXaP5/0HoouOXdI9g2m8Gr3+4gKdVK0yq+9G9ZOc+uJYWbwo2IiGTN5Yuw9n3YNAOsqYDFPk9N25FQMijPL//fDUfZ+NcFPFwcef+xhjjodpTcgsKNiIj8s/QU2DQT1k6G5Ev2tipt7IOFyzbMlxKOxCQwcfl+AIY/VIeKpT3y5bpSOCnciIjIzRkG7F5svwV16Zi9zb+ufQ2o6u3zZLDwzVhtBq8t2klymo27qpfmiaYV8+W6Ungp3IiIyI2OrodfR8LpbfbXJQKh7QgIeeKOlkvIiVm/H2HrsYuUcHVikm5HSRYo3IiIyDUxB2DlaIj82f7apQTc9TK0GAgunvlezsHoeN7/9QAAbz1ch/Il72zJBikeFG5ERAQSzsLq8bD1v2BYweIIjfvBPcOhhL8pJaVbbbz67Q5S023cU6sMPcLyftCyFA0KNyIixVlqImz4BNZ/BKkJ9rZaD0H7MVCmpqmlfb72CDtOxuLt5sSErsFY8mmMjxR+CjciIsWRzQoRX8Oq9yAhyt5WrhHc/y5Uvsvc2oB9Z+KYutJ+O+rtR+oR6ONmckVSmCjciIgURytGwYZp9u2SFaHdaKjXFRwczK0LSLPaeOWbHaRZDe6rG0CX0PJmlySFjMKNiEhxc+4QbJxu32432j5Y2MnV3JquM23VIfaeiaOkhzPvdamv21GSbQo3IiLFzcrRYEuHGh3sSyYUILtPxfLJb4cAGPtoffy9dDtKss/8/kcREck/x/6A/T+BxcE+GV8BkpJuZeg3EaTbDDo2KEunhuXMLkkKKYUbEZHiwmaDX0bYtxv1A//a5tbzNx+tPMiB6ARKe7rwzqP1zC5HCjGFGxGR4mLPd/YZh11KwL1vml1NJtuPX2T6msMAvNelAaVLFJwxQFL4KNyIiBQHacmwcox9u9Vg0ybmu5nkNCuvfLsDmwGdQ8rxQP1As0uSQk7hRkSkONg0A2KPg1c5aD7Q7GoymfJrJEdiEvH3cuXtR3Q7Su6cwo2ISFGXeB7Wvm/fbvcWuHiYW891Nh+9wH9+/wuACd0aUNLDxeSKpChQuBERKerWToKUWAhsAME9za4mQ1JqOq9+uwPDgO6NK9C2doDZJUkRoXAjIlKUnT8Mm/9j377/XXBwNLee60xaHsmx80mU9XHjrU51zS5HihCFGxGRoixjwr77oeo9ZleT4Y/D55jzx1EAJnYLxtvN2dyCpEhRuBERKaqObYB9Pxa4CfsSUtJ5fdFOAB5vVpG7a5YxuSIpahRuRESKIsOAX69O2NcX/OuYW8913lu2j5MXL1OhlDtvPlRw6pKiQ+FGRKQo2vMdnNoKzp5wT8GZsG/tgRjmbzoOwKTHginhqiUOJfcp3IiIFDXpKbDybft2q8HgVTCeQoq9nMYbi+23o55qWZmW1fxMrkiKqhyFm99++y236xARkdyyaQZcOg5eZaFFwZmwb+xPezkTm0zl0h68/kAts8uRIixH4eaBBx6gWrVqvPvuu5w4cSK3axIRkZxKugBrJ9u3244EF09z67kifF80i7aexGKB97s3xMNFt6Mk7+Qo3Jw6dYpBgwaxaNEiqlatSocOHfjmm29ITU3N7fpERCQ71k6G5FgIqA8Ne5tdDQCXklIZ9t0uAJ5pVYWwyr4mVyRFXY7CjZ+fH0OGDCEiIoKNGzdSs2ZNXnjhBcqVK8dLL73Ejh07crtOERG5nfOHYdNM+/b9YwvMhH2jl+4hJj6FamU8eeV+3Y6SvHfHA4obNWrE8OHDGTRoEAkJCcyePZvGjRvTunVr9uzZkxs1iohIVoSPAVsaVG8P1dqaXQ0Ay3efYUnEaRwsMKVHCG7OBSNwSdGW43CTlpbGokWLeOihh6hUqRK//PIL06ZNIzo6mkOHDlGpUiW6d++em7WKiMitHN8Ie5dcmbBvrNnVAHA+IYUR3+8G4Pk21QgJKmluQVJs5GhE14svvsj8+fMxDIM+ffowadIk6tevn/G+p6cn77//PuXKlcu1QkVE5Baun7Av9EkIMH+dJsMweGvJbs4nplI70IuX29cwuyQpRnIUbvbu3cu///1vunbtiqur60338fPz0yPjIiL5Ye8PcHIzOHvAvSPMrgaAH3ee4eddUTg5WHi/e0NcnXQ7SvJPjsJNeHj47U/s5ESbNm1ycnoREcmq6yfsu+tl8Ao0tRyAs/HJjFpivx01qG116pf3MbkiKW5yNOZm/PjxzJ49+4b22bNnM3HixDsuSkREsmjzf+DiUSgRCC1fNLsaDMPgze92cykpjXrlvBl4b3WzS5JiKEfh5vPPP6d27do3tNerV4/p06ffcVEiIpIFSRdgzST7dtsRBWLCvu+2nWLlvmicHS1M6dEQZ0et8iP5L0c/dVFRUZQtW/aG9jJlynDmzJk7LkpERLJg3RRIvgT+dSHkCbOrISo2mbd/tE8BMrh9TWoHeptckRRXOQo3QUFBrF+//ob29evX6wkpEZH8cOEv2Pi5fbsATNhnGAZvLN5JfHI6DYNK8tzdVU2tR4q3HIWbAQMGMHjwYL744guOHTvGsWPHmD17NkOGDGHAgAHZPt8nn3xC5cqVcXNzo1mzZmzatClLxy1YsACLxULnzp2zfU0RkULt6oR91draJ+0z2cLNJ1hzIAYXJwemdA/GSbejxEQ5elrqtdde4/z587zwwgsZ60m5ubnxxhtvMHz48Gyda+HChQwdOpTp06fTrFkzpk6dSocOHYiMjMTf3/+Wxx09epRXX32V1q1b5+RTEBEpvE5sgj3fA5YCMWHfyYtJvLtsHwCv3V+L6v5eJlckxZ3FMAwjpwcnJCSwb98+3N3dqVGjxi3nvPknzZo1o0mTJkybNg0Am81GUFAQL774IsOGDbvpMVarlbvvvpunn36adevWcenSJX744YcsXS8uLg4fHx9iY2Px9tb9YBEpZAwDZneAExvtE/Y9+omp5dhsBn1mb2T9ofOEVSrFwuda4OhgMbUmKZqy8/f7jvoNS5QoQZMmTahfv36Ogk1qaipbt26lfftrXaoODg60b9+eDRs23PK4d955B39/f/71r3/d9hopKSnExcVl+hARKbT2LbUHmwIyYd/XG4+x/tB53JwdmNy9oYKNFAg5ui0FsGXLFr755huOHz+ecWvqqu+++y5L5zh37hxWq5WAgIBM7QEBAezfv/+mx/z+++/MmjWLiIiILF1j/PjxjBkzJkv7iogUaOmpsGK0fbvli+Bt7gMcx84nMu5n++/qYQ/Upoqf+Y+ii0AOe24WLFhAy5Yt2bdvH99//z1paWns2bOHVatW4eOTdzNRxsfH06dPH2bOnImfn1+Wjhk+fDixsbEZHydOnMiz+kRE8tSWWXDxL/D0h5YvmVqKzWbw2rc7uZxmpXlVX/q2qGxqPSLXy1HPzbhx4/jwww8ZOHAgXl5efPTRR1SpUoXnnnvupvPf3Iqfnx+Ojo5ER0dnao+OjiYw8MYpxA8fPszRo0fp1KlTRpvNZrN/Ik5OREZGUq1atUzHuLq65uiWmYhIgXL5Iqy5MgN82xHgWsLUcr744yibjl7A08WRyY81xEG3o6QAyVHPzeHDh+nYsSMALi4uJCYmYrFYGDJkCDNmzMjyeVxcXGjcuHGmtapsNhvh4eG0aNHihv1r167Nrl27iIiIyPh45JFHuPfee4mIiCAoKCgnn46ISMG3boo94PjXhdA+ppZyOCaBScvtt6Pe7FiHIF8PU+sR+bsc9dyUKlWK+Ph4AMqXL8/u3btp0KABly5dIikpKVvnGjp0KP369SMsLIymTZsydepUEhMT6d+/PwB9+/alfPnyjB8/Hjc3N+rXr5/p+JIlSwLc0C4iUmRcPHptwr77zJ2wz2ozePXbHaSk22hdw4/Hm1Y0rRaRW8lRuLn77rtZsWIFDRo0oHv37rz88susWrWKFStW0K5du2ydq2fPnsTExDBq1CiioqIICQlh+fLlGYOMjx8/joODJoMSkWIs/B2wpkLVe6F69n7H5raZ646w/fglvFydmNgtGItFt6Ok4MnRPDcXLlwgOTmZcuXKYbPZmDRpEn/88Qc1atRg5MiRlCpVKi9qzRWa50ZECpWTW+A/7QALPL8OAhuYVsqB6Hge/vh3Uq02Jj0WTI8wDQWQ/JOdv9/Z7rlJT0/np59+okOHDoB9XppbTbYnIiJ3wDDg15H27ZAnTA02aVYbr3yzg1SrjXa1/eneuIJptYjcTrbv9zg5OfH888+TnJycF/WIiMhV+36E4xvAyd3+hJSJpq8+zK5Tsfi4OzOuawPdjpICLUeDWZo2bZrlSfRERCQH0lNhZcGYsG/v6Tg+XnUQgDGP1CPA2820WkSyIkcDil944QWGDh3KiRMnaNy4MZ6emWelDA4OzpXiRESKrS2z4cIR+4R9d5k3YV9quo2h30SQZjXoUC+AR0PMnRVZJCtyFG569eoFwEsvXfsHZ7FYMAwDi8WC1WrNnepERIqjy5dgzQT79r1vgqt5q2xPW3WQ/VHx+Hq68F4X3Y6SwiFH4eavv/7K7TpEROSqqxP2lalt6oR9O09e4pPVhwEY+2h9/EpotncpHHIUbipVqpTbdYiICMDFY7Bxun37vrHgmOP1je9IcpqVV77ZgdVm8HBwWToGZ31pHRGz5ehfzdy5c//x/b59++aoGBGRYu/qhH1V2kCN+0wrY+rKgxw8m4BfCVfGPqoZ4KVwyVG4efnllzO9TktLIykpCRcXFzw8PBRuRERy4uRW2L0IsMD974JJ41u2Hb/IjLX221HjutSnlKeLKXWI5FSOHgW/ePFipo+EhAQiIyNp1aoV8+fPz+0aRUSKvusn7GvYG8qa89Tp5VQrr36zA5sBXUPLc3+9QFPqELkTubZoU40aNZgwYcINvToiIpIF+5fB8T/AyQ3ajjStjPd/jeTIuUQCvF0Z3ameaXWI3IlcXZHSycmJ06dP5+YpRUSKPmsarBhl324xCHzKm1LGpr8uMHu9/WnYCd2C8fFwNqUOkTuVozE3S5cuzfTaMAzOnDnDtGnTuOuuu3KlMBGRYmPLF3DhMHiWgVaDTSkhMSWdV7/dgWFAz7Ag7q3lb0odIrkhR+Gmc+fOmV5bLBbKlClD27ZtmTJlSm7UJSJSPCTHwurx9u17hps2Yd+E/+3n+IUkypd0Z+TDdUypQSS35Cjc2Gy23K5DRKR4WvcBXL4AfjWhUT9TSlh/6Bxf/nkMgEmPBePlpttRUrjl6pgbERHJhkvH4c/P7NsmTdgXn5zG64t2AtCneSXuqu6X7zWI5LYchZtu3boxceLEG9onTZpE9+7d77goEZFiIXwsWFOgcmuo2cGUEt5bto9Tly5T0deDYQ/WNqUGkdyWo3Czdu1aHnrooRvaH3zwQdauXXvHRYmIFHmntsGub+zbJk3YtzryLAs2n8BigcmPBePpas5SDyK5LUfhJiEhAReXG2esdHZ2Ji4u7o6LEhEp0gwDfn3Lvh3cC8qF5HsJsZfTGLZ4FwD9W1ahWdXS+V6DSF7JUbhp0KABCxcuvKF9wYIF1K1b946LEhEp0iL/B8d+N23Cvt2nYun5+Qai4pKp4ufJax1q5XsNInkpR32Qb731Fl27duXw4cO0bdsWgPDwcObPn8+3336bqwWKiBQp10/Y1/wFKBmUb5dOSbfycfhBpq85gtVm4Ovpwke9QnB3ccy3GkTyQ47CTadOnfjhhx8YN24cixYtwt3dneDgYFauXEmbNm1yu0YRkaJj6xw4fxA8/KDVkHy7bMSJS7z27Q4Onk0A4OHgsox5pB6lS7jmWw0i+SXHo8c6duxIx44dc7MWEZGiLdOEfcPAzTvvL5lm5cOVB5i59gg2A/xKuPBu5/o8UL9snl9bxCw5CjebN2/GZrPRrFmzTO0bN27E0dGRsLCwXClORKRI+X0qJJ2H0jWg8VN5frmtxy7w2qKdHIlJBKBzSDlGd6pHKc8bHwgRKUpyNKB44MCBnDhx4ob2U6dOMXDgwDsuSkSkyLl0Av781L593zvgmHezAF9OtTL2p708Nn0DR2IS8fdy5T99w5jaK1TBRoqFHPXc7N27l0aNGt3QHhoayt69e++4KBGRImfVu5CeDJVaQa0H8+wyG4+c543FOzl6PgmAxxpX4K2OdbXCtxQrOQo3rq6uREdHU7Vq1UztZ86cwclJk0CJiGRyOgJ2LrBv3z82TybsS0pNZ9LySOb8cRSAsj5ujOvaQKt7S7GUo9tS999/P8OHDyc2Njaj7dKlS7z55pvcd999uVaciEihZxjw65W5bIJ7Qvkbe73v1B+Hz9Fh6tqMYNOrSRC/DLlbwUaKrRx1s7z//vvcfffdVKpUidDQUAAiIiIICAjgyy+/zNUCRUQKtQO/wNF14OgKbd/K1VMnpKQz/ud9fL3xOADlS7ozoVsDWtcok6vXESlschRuypcvz86dO/n666/ZsWMH7u7u9O/fn969e+PsrPu6IiIAWNNhxZVA0yJ3J+xbdzCGYYt3cerSZQCebF6RYQ/WoYTWhxLJ+Tw3np6etGrViooVK5KamgrA//73PwAeeeSR3KlORKQw2/ZfOHcAPErn2oR9cclpjFu2jwWb7U+sBvm6M7FbMC2r+eXK+UWKghyFmyNHjtClSxd27dqFxWLBMAws1w2Qs1qtuVagiEihlBx33YR9w8HN545P+VvkWd78bhdnYpMBeKplZV7rUEureYv8TY4GFL/88stUqVKFs2fP4uHhwe7du1mzZg1hYWGsXr06l0sUESmE1n8EiTFQuvodT9gXm5TGK9/soP8XmzkTm0zl0h5881wL3n6knoKNyE3k6F/Fhg0bWLVqFX5+fjg4OODo6EirVq0YP348L730Etu3b8/tOkVECo/Yk7Bhmn37DifsW7k3mje/38XZ+BQsFvjXXVV45f5aWuxS5B/kKNxYrVa8vLwA8PPz4/Tp09SqVYtKlSoRGRmZqwWKiBQ6GRP23QW1HsrRKS4mpjLmxz38EHEagKplPJn8WDCNK/nmZqUiRVKOwk39+vXZsWMHVapUoVmzZkyaNAkXFxdmzJhxw8R+IiLFyukI2HFnE/Yt332GkT/s4VxCCg4WGHB3VYa0r4mbs3prRLIiR+Fm5MiRJCbaF2J75513ePjhh2ndujWlS5dm4cKFuVqgiEihkTFhnwENukP5xtk6/HxCCqOW7mHZzjMA1PAvwaTHggmtWCoPihUpunIUbjp06JCxXb16dfbv38+FCxcoVapUpqemRESKlYO/5mjCPsMwWLbrDKOW7OFCYiqODhaeb1OVl9rVwNVJvTUi2ZVrw+x9fXUfWESKMWs6/Hol0DR/HkpVytJhMfEpvPXDbpbviQKgdqAXkx9rSIMKd/7ouEhxpWcIRURyw/a5cC4S3H2h1dDb7m4YBksiTvP2j3u4lJSGk4OFF+6tzqB7q+PilKNZOkTkCoUbEZE7lRIPv42zb98zDNxL/uPuZ+OSefP73azcFw1A3bLeTO4eTL1y6q0RyQ0KNyIid+rqhH2+1aBx/1vuZhgGi7ed4p0f9xCXnI6zo4WX2tbg+Xuq4eyo3hqR3KJwIyJyJ2JPwR9XJ+wbA04uN93tTOxlhn+3i9WRMQAEV/Bh0mPB1A70zq9KRYoNhRsRkTvx23uQfhkqtoDaD9/wtmEYfLPlBO/+tI/4lHRcHB0YfF8Nnm1dFSf11ojkCYUbEZGcOrMTIubZt+9/94YJ+05eTGL4d7tYd/AcACFBJXm/ezDV/b3yu1KRYkXhRkQkJ66fsK9+N6gQlvGWzWYwb9Nxxv+8j8RUK65ODrx6fy2eblUFRwfNBSaS1xRuRERy4tBK+GsNOLpAu1EZzScuJPH6op1sOHIegLBKpZj0WDBVy5Qwq1KRYkfhRkQku6zpV3ptgGbPQanK2GwGX/55jInL95OUasXN2YHXO9SmX8vK6q0RyWcKNyIi2RXxFcTsB/dS0PoVjp5L5PXFO9n01wUAmlXxZdJjwVQq7WlyoSLFk8KNiEh2pCTAqvcAsN39OrO3XOT9XyNJTrPh4eLI8Adr80SzSjiot0bENAo3IiJZYRhwbD38PhUSz5LmXZknttVl04l9ALSsVpqJ3YIJ8vUwt04RUbgREflHiefsj3tv+y+cPwSAgYVBF7uzKS2REq5OvPlQHXo3DcJiUW+NSEFQIGaQ+uSTT6hcuTJubm40a9aMTZs23XLf7777jrCwMEqWLImnpychISF8+eWX+VitiBR5NhscWQ3fPgVTasOKt+D8IQxnT8I9HuThlHf5JS2Uu2uW4Zchd/N4s4oKNiIFiOk9NwsXLmTo0KFMnz6dZs2aMXXqVDp06EBkZCT+/v437O/r68uIESOoXbs2Li4u/PTTT/Tv3x9/f386dOhgwmcgIkVGfDREfG3vpbl49Fp7uUacrtaDfpsqcvACeLo4MqlTPbqHVVCoESmALIZhGGYW0KxZM5o0acK0afa1WWw2G0FBQbz44osMGzYsS+do1KgRHTt2ZOzYsTe8l5KSQkpKSsbruLg4goKCiI2Nxdtba7qIFHs2Kxz+DbbNgcj/gS3d3u7qDcE9oFE/lsWU4dVvd3A5zUrl0h7M6BtGzQDNMiySn+Li4vDx8cnS329Te25SU1PZunUrw4cPz2hzcHCgffv2bNiw4bbHG4bBqlWriIyMZOLEiTfdZ/z48YwZMybXahaRIiLuNGz/CrZ9CbHHr7VXaAqN+0G9LticPJiyIpJPftsGQOsafkzr3QgfD2eTihaRrDA13Jw7dw6r1UpAQECm9oCAAPbv33/L42JjYylfvjwpKSk4Ojry6aefct9999103+HDhzN06NCM11d7bkSkGLJZ4eAK+22nA8vBsNnb3XygYW9o1A8C6gIQl5zGkLlbCN9/FoDn7q7K6w/U1oR8IoWA6WNucsLLy4uIiAgSEhIIDw9n6NChVK1alXvuueeGfV1dXXF1dc3/IkWk4Lh0wt5Ls/1LiDt1rb1iS3svTd1Hwdk9o/lITALPzN3CkZhEXJ0cmNgtmM6h5U0oXERywtRw4+fnh6OjI9HR0Znao6OjCQwMvOVxDg4OVK9eHYCQkBD27dvH+PHjbxpuRKSYsqbBgV/svTQHVwBXhhe6+0LI49CoL5SpdcNhv0We5aX524lPTqesjxuf92lMcIWS+Vq6iNwZU8ONi4sLjRs3Jjw8nM6dOwP2AcXh4eEMGjQoy+ex2WyZBg2LSDF28ah9HM32ryAh6lp75dbQ+Cmo/TA4u91wmGEYTF9zhEm/7Mcw7AtefvpkI/y9btxXRAo2029LDR06lH79+hEWFkbTpk2ZOnUqiYmJ9O/fH4C+fftSvnx5xo8fD9gHCIeFhVGtWjVSUlL4+eef+fLLL/nss8/M/DRExEzpqRD5s72X5vBvZPTSePhB6BP2sTSlq93y8MupVl5fvJMfd5wGoHfTiox5pB4uTgViKjARySbTw03Pnj2JiYlh1KhRREVFERISwvLlyzMGGR8/fhwHh2u/YBITE3nhhRc4efIk7u7u1K5dm6+++oqePXua9SmIiFnOH7YHmoh5kBhzrb3qvfaxNLU6gpPLP57i1KXLPDt3C3tOx+HkYOHtR+rxZPNKeVy4iOQl0+e5yW/ZeU5eRAqg9BTY9yNsnQNH111rLxEAoU9CaB/wrZKlU208cp4Xvt7G+cRUSnu68OkTjWhWtXTe1C0id6TQzHMjIpJlMQeu9dJcvnCl0QLV29vH0tTsAI5Zn3/mqz+P8fbSPaTbDOqV82ZG3zDKl3S//YEiUuAp3IhIwZV2GfYutffSHP/jWrtXOWjUx95TU7Jitk6Zmm5j9NI9zN9kn7ivU8NyTOoWjLuLYy4WLiJmUrgRkYIneq+9l2bHAki+ZG+zOECNDvZemurtwTH7v75i4lP4v6+2suXYRSwWeL1DbZ5vU1XrQ4kUMQo3IlIwpCbBnu/tvTQnN11r9wmyz0kT8gT45HwivZ0nL/Hcl1s5E5uMl5sTH/cK5d7aNy7OKyKFn8KNiJgrapc90Oz8FlJi7W0WR6j1IDTuD9XuBYc7u2X0w/ZTvLF4JynpNqqW8WRm3zCqlSlx57WLSIGkcCMi+S8lAXYvtoea09uutZesZH+EO+QJ8Lr1LOVZZbUZTFy+nxlrjwDQtrY/U3uF4O2mhS9FijKFGxHJP6e32wPNrkWQmmBvc3CG2h3tY2mqtAGH3Jk4LzYpjRcXbGftAfv8NwPvrcbQ+2pp4UuRYkDhRkTyVmqiPcxsmQVndlxr961qDzQNH4cSZXL1kgej4xkwdwtHzyfh7uzI5O7BPBxcLlevISIFl8KNiOSNmEjYPMv+xNPVsTSOLlDnEXuoqdwK8uAppRV7oxm8YDuJqVbKl3RnRt/G1Cvnk+vXEZGCS+FGRHJPeirs/wm2zM48e3CpyhD2NIQ8CZ55MwOwzWYw7bdDfLDiAADNqvjy6RONKF3CNU+uJyIFl8KNiNy5SyfsY2m2zYXEs/Y2iwPUfBCaPA1V2+baWJqbSUxJ59Vvd/C/3fZVwPu1qMTIh+vi7KiFL0WKI4UbEckZmw0Or4LN/4GDv4Bhs7eXCLDPS9P4KfCpkOdlnLiQxIC5W9gfFY+zo4Wxj9anV9PszVosIkWLwo2IZE/iOdj+FWz9Ai4evdZeuTU0+RfUfjhbazzdifWHzjFw3jYuJaXhV8KVz/s0onEl33y5togUXAo3InJ7hgEnNtoHCO/9Aayp9nZXHwh53D6epkzNfCzHYM4fR3l32T6sNoPgCj583qcxZX208KWIKNyIyD9JiYedC2HzbDi751p7uVAI+xfU7wYuHvlaUnKalZE/7GbR1pMAdA0tz7iuDXBz1sKXImKncCMiN4reY++l2bnw2mR7Tu72MNPkaSjf2Jyy4pJ57sutRJy4hIMF3nyoDv9qVUULX4pIJgo3ImKXngJ7l9hDzYk/r7WXrnHlMe7e4F7KtPK2Hb/I819u5Wx8Cj7uzkx7PJTWNXJ38j8RKRoUbkSKuwt/2QcHb/8Kks7b2xyc7EsihP0LqtydJ5PtZcc3W04w8vvdpFpt1Awowcy+YVQq7WlqTSJScCnciBRHNisc+MW+JMKhcMCwt3uXtz/C3ahvrixceafSrDbeW7aPOX8cBeD+ugF80DOEEq761SUit6bfECLFSXw0bJ8LW+ZA3Mlr7dXa2R/jrtEBHAvGr4WLiakMnLeNPw7be5MGt6/BS21r4KCFL0XkNgrGbzERyTuGAUd/t/fS7PsRbOn2dndfCH0CGveH0tXMrfFv9p2J49kvt3DiwmU8XBz5oEcID9Q3vydJRAoHhRuRouryJfuilVtmw7nIa+0Vmtp7aep2Bmc3s6q7pf/tOsPQb3ZwOc1KRV8PZvYNo1agl9lliUghonAjUtScjrD30uxaBGlJ9jZnTwjuYQ81gQ1MLe9WbDaDqSsP8PGqQwC0qu7HtMdDKenhYnJlIlLYKNyIFAVpl2H3d/ZQc2rrtXb/uvbHuIN7gpu3efXdRnxyGkMW7mDlvmgA/tWqCsMfrI2TFr4UkRxQuBEpzM4dst92ivgaki/Z2xycoe6j0OQZqNjc9Me4b+evc4kMmLuFQ2cTcHFyYHyXBnRrnPcLbopI0aVwI1LYWNMg8mf7ZHt/rbnWXrKifXBwaB8oUTgmt1tzIIYX520jLjmdAG9XPu8TRkhQSbPLEpFCTuFGpLCIOw1b/wvb/gvxZ640WqBmB/tke9XbgUPhWF/JMAxmrD3CxOX7sRnQqGJJpj/ZGH/vgjfAWUQKH4UbkYLuzA5YMwki/weG1d7mWcY+0V7jp+w9NoVIcpqVNxbvZEnEaQB6hgXxTud6uDoVjmAmIgWfwo1IQRYfBXMehpQ4++tKrewLV9buBE6F7ymi05cu89yXW9l1KhZHBwujHq5L3xaVtPCliOQqhRuRgmz5MHuwKdsQunwO/nXMrijHNh45z8B52ziXkEopD2c+faIxLaqVNrssESmCFG5ECqqDK2HP92BxhEemFdpgk2a18dHKg3y6+hA2A2oHejGzbxhBvh5mlyYiRZTCjUhBlJoEy4bat5v/H5QNNreeHDoSk8CQhRHsOBkLQNdG5Xm3c308XPSrR0Tyjn7DiBREayfDpWPgXQHuGW52NdlmGAbzN51g7E97uZxmxdvNiXFdG/BwcDmzSxORYkDhRqSgid4Lf3xs335oMriWMLeebDqfkMIbi3dlzDbcslpppvRoSFkfd5MrE5HiQuFGpCCx2eCnIfaVu2s/DLUfMruibPkt8iyvfbuTcwkpuDg68FqHWvyrVRUcHPQ0lIjkH4UbkYJk+5dw4k9wKQEPTjS7mixLTrMy/ud9/HfDMQBq+Jfgo16h1C1XcNezEpGiS+FGpKBIiIEVo+zb974JPoVjfaU9p2N5eUEEh84mAPBUy8oMe7A2bs6alE9EzKFwI1JQ/DrSvvhlYANo+pzZ1dyWzWYwc90R3v81kjSrQRkvVyY/Fsw9tfzNLk1EijmFG5GC4Mga2LkAsMDDH4Fjwf6nefrSZV75ZgcbjpwH4L66AUzo2oDSJVxNrkxEROFGxHxpyfZBxABNnoEKjc2t5zZ+3HGaEd/vIi45HXdnR0Z3qkvPJkFaQkFECgyFGxGz/f4hXDgMJQKh3VtmV3NL8clpjF6yh++2nwKgYQUfpvYKpYqfp8mViYhkpnAjYqZzB+H3D+zbD04ANx9z67mFzUcvMGRhBCcvXsbBAoPurc6L7Wrg7OhgdmkiIjdQuBExi2HYl1iwpkL1+6BuZ7MrusHf14UK8nXnwx4hhFX2Nbs0EZFbUrgRMcvOhfDXWnByh47vQwEbs3KzdaHGPFIPLzdnkysTEflnCjciZki6AL+8ad9u8zqUqmxqOdf7+7pQPu7OvNelvtaFEpFCQ+FGxAwrRkHSeShTB1q+aHY1GbQulIgUBQo3Ivnt2B/2ZRYAOk0Fx4Jxm0frQolIUaFwI5Kf0lOvzWnTqB9UbG5uPWhdKBEpehRuRPLThn9DzH7w8IP2b5tdjdaFEpEiSeFGJL9c+AvWTLJvdxgHHuY9Tn2zdaHe796QNjXLmFaTiEhuUbgRyQ+GActegfRkqNIGgnuYVsrpS5cZ+k0Efx65AMD9dQOY0C0YX08X02oSEclNBWJ60U8++YTKlSvj5uZGs2bN2LRp0y33nTlzJq1bt6ZUqVKUKlWK9u3b/+P+IgXCnu/gcDg4ukDHD0yb0+bHHad5YOpa/jxyAXdnRyZ0bcDnfRor2IhIkWJ6uFm4cCFDhw5l9OjRbNu2jYYNG9KhQwfOnj170/1Xr15N7969+e2339iwYQNBQUHcf//9nDp1Kp8rF8miy5dg+XD7dutXwK96vpcQl5zG0IURvDh/O3HJ6TQMKsnPL7emV9OKWvBSRIoci2EYhpkFNGvWjCZNmjBt2jQAbDYbQUFBvPjiiwwbNuy2x1utVkqVKsW0adPo27fvbfePi4vDx8eH2NhYvL31NIjkg2WvwOb/QOnq8H9/gJNrvl5+89ELDF4QwalLWhdKRAqv7Pz9NnXMTWpqKlu3bmX48OEZbQ4ODrRv354NGzZk6RxJSUmkpaXh63vzwZkpKSmkpKRkvI6Li7uzokWy4+RW2DzLvv3wh/kabLQulIgUV6b+r9u5c+ewWq0EBARkag8ICCAqKipL53jjjTcoV64c7du3v+n748ePx8fHJ+MjKCjojusWyRJrOvz0MmBAw95Q5e58u/SRmAS6ffYH036zB5tujSrw80utFWxEpFgo1E9LTZgwgQULFrB69Wrc3Nxuus/w4cMZOnRoxuu4uDgFHMkfG6dD1C5wLwX3v5svl7zZulDjujSgY3DZfLm+iEhBYGq48fPzw9HRkejo6Ezt0dHRBAYG/uOx77//PhMmTGDlypUEBwffcj9XV1dcXfN3jIMIl07Ab+/Zt+97Bzz98vySWhdKRMTO1NtSLi4uNG7cmPDw8Iw2m81GeHg4LVq0uOVxkyZNYuzYsSxfvpywsLD8KFUke/73OqQlQcUWEPJknl/ut8izdJi6jpX7onFxdGDEQ3X46l/NFGxEpFgy/bbU0KFD6devH2FhYTRt2pSpU6eSmJhI//79Aejbty/ly5dn/PjxAEycOJFRo0Yxb948KleunDE2p0SJEpQoUcK0z0Mkw76fIPJncHCyDyJ2yLv/h/j7ulA1A0owtafWhRKR4s30cNOzZ09iYmIYNWoUUVFRhISEsHz58oxBxsePH8fhuj8On332GampqTz22GOZzjN69Gjefvvt/Cxd5EYp8fZeG4CWL4F/nTy7lNaFEhG5OdPnuclvmudG8tTyN+HPT6BUZfi/DeDikeuX0LpQIlIcFZp5bkSKlDM7YONn9u2OU/Ik2GhdKBGR21O4EckNNiv8+DIYNqjXFarffN6lO/HjjtOM+H4XccnpeLg4MrpTXXqEBWn5BBGRv1G4EckNm2fB6e3g6g0PjM/VU8clp/H2kj18t92+flrDoJJM7RlCFT/PXL2OiEhRoXAjcqfizkD4O/btdqPA65/naMqO7ccv8tKC7Zy4oHWhRESySuFG5E4tHwap8VC+MYQ9nSuntNkMpq89zAe/HiDdZlChlDsf9QqhcSUtnyAicjsKNyJ34uAK2PsDWBzh4angcOePYZ+NT2bowh38fugcAA8Hl2Vc1wZ4uznf8blFRIoDhRuRnEpNgmVX1i1r/n9Q9tbLgGTV6sizvPLNDs4npuLu7MiYR+rRPayCBg2LiGSDwo1ITq2dBJeOg3cFuGf4HZ0qNd3G5F/2M3PdXwDUDvRi2uOhVPf3yo1KRUSKFYUbkZyI3gt//Nu+/dBkcM350h9HzyXy0oLt7DwZC0C/FpUY/lAdzTQsIpJDCjci2WWzwU+DwZYOtR+G2g/l+FQ/bD/FiO93kZhqpaSHM5O6BXN/vdx72kpEpDhSuBHJru1z4cRGcCkBD07M0SkSU9IZtWQPi7edBKBpFV+m9gyhXEmt4i0icqcUbkSyIyEGVoy2b9/7JvhUyPYpdp+K5aX52zlyLhEHC7zUrgYvtq2Bo4MGDYuI5AaFG5Hs+HUEJF+CwAbQ9LlsHWoYBl+sP8qE/+0n1WqjrI8bU3uG0Kxq6bypVUSkmFK4EcmqI6th50LAAp0+Ases//O5kJjKa9/uIHz/WQDuqxvApG7BlNKClyIiuU7hRiQr0pLhpytz2jQdYJ+NOIv+OHyOIQsjiI5LwcXJgZEd69CneSXNXSMikkcUbkSy4vcP4MJhKBEIbUdm6ZB0q42Pwg8y7bdDGAZUK+PJv3s3om457zwuVkSkeFO4Ebmdcwfh9w/t2w9OADef2x5y8mISgxdEsOXYRQB6hgUx+pG6eLjon5yISF7Tb1qRf2IY8NMQsKZC9fugbufbHrJ89xleX7STuOR0vFydGNe1AZ0alsv7WkVEBFC4EflnOxbA0XXg5A4d34d/GCeTnGZl7E97+XrjcQAaBpXk371CqVjaI7+qFRERFG5Ebi3pgv3Rb4B73oBSlW+564HoeF6ct53I6HgAnm9TjVfur4mzo0M+FCoiItdTuBG5lRVvQdJ58K8LLQbddBfDMJi/6QTv/LSH5DQbfiVc+bBnQ1rXKJPPxYqIyFUKNyI3c+wP2P6VffvhqeDofMMusZfTGP7dTn7eFQXA3TXLMKV7Q8p4ueZjoSIi8ncKNyJ/l54KPw62bzfqBxWb3bDL1mMXeGl+BKcuXcbJwcLrD9TimVZVcdASCiIiplO4Efm7Pz6Gc5Hg4Qft3870ltVmMH3NYT5YcQCrzaCirwf/7h1Kw6CSppQqIiI3UrgRud6FI7B2sn27wzjw8M14KzoumSELI/jj8HkAHg0px7ud6+PlduMtKxERMY/CjchVhgHLXoX0ZKjSBoJ7ZLy1an80r367kwuJqbg7O/LOo/V4rHEFLaEgIlIAKdyIXLV7MRwOB0dX6PgBWCykpFuZtDySWb//BUDdst78+/FQqpUpYXKxIiJyKwo3IgCXL8Hy4fbt1q+AX3X+OpfIi/O3sftUHABPtazMsAdr4+bsaF6dIiJyWwo3IgDh70DiWShdA1oN5rttJ3nrh90kplop5eHM5Mca0r5ugNlViohIFijciJzcAltmA3C5w2TeXLyP77efAqBZFV8+6hVKoI+bmRWKiEg2KNxI8WZNvzKnjcHFGt3osgSOnj+FgwUGt6/JwHur46i5a0REChWFGyneNn4G0btIdvLhgb33E21NopyPGx/1DqVJZd/bHy8iIgWOwo0UX5eOY6wahwUYdbkH0VYvOtQLYGK3YEp6uJhdnYiI5JDCjRRPhsGFbwfjm57ERlttlljuZWzn+jzZrKLmrhERKeQUbqTYSbPa+GnhDLqcCifVcORzr0Es6dOa2oHeZpcmIiK5QOFGipUTF5J4fd56PoiZCBZYH/A4nzzzOO4umrtGRKSocDC7AJH8smznGR76eB3to2ZR1nKBRM8g7h0wWcFGRKSIUc+NFHmXU62889Me5m86QT3LXzzl+gsAnl2mgrO7ucWJiEiuU7iRIm1/VBwvztvOwbMJOFps/Mf3KxwTbVCvK1Rvb3Z5IiKSBxRupEgwDINLSWlExSUTFZfM2bhkjpxLZM76o6Sk2yjj5crChjsou2UfuHrDA+PNLllERPKIwo0UeMlpVs7GpWQKLlGx9u3ouKv/TSE13XbT4++pVYYPHvDH94un7A3tR4NXYP59AiIikq8UbsQ0NpvBhaRUomLtISX6SoCJvi64RMclczEpLcvnLO3pgr+3G4HergT6uNG4ki9dQ8vjsKgfpMZD+TBo/HQeflYiImI2hRvJE5dTrfaelthkzsb/racl1h5kzsYnk2Y1snQ+VycHAn3cCPB2I9DbLWM7wNuVQG/7tr+3K65ON3ny6cCvsHcJWByh01Rw0EOCIiJFmcKNZIvVZnA+ISUjuETHp2TqabnaCxOXnJ6l81ksUNrTlUAfe0jxvxpevN0I8Lm27e3ulLOZg1MTYdkr9u3m/weBDbJ/DhERKVQUboqxNKuNpBQrSWnpJKVauZxqJSnVSlJqOhcSUzPdIoqKS+FsXDJn41Ow2rLW2+Lu7Hilh8X1hrDif6X3xd/LFWfHPOxJWTMRYo+DdwW4Z3jeXUdERAoMhZsCLjXdZg8dNwkgSVe2L1+/nXbdeylWktKuvX/9sZfTrFm+JfR3DhbwK+Ga6TZRgLerfdvnWq+Ll2sOe1tyS/Qe2PCJffuhyeBawrxaREQk3yjc5JK0kzuwLHoKm2FgGNj/i/0RZZtx/X+vvGcY2LC/vnGfq+/Zz3WVBfC48nHHHK98YL81ZMGCgwUsFgsWCzhaLDg6WnBysODoYMHJweHKf+2vLQA24NKVj4Io6TzY0qH2w1D7IbOrERGRfKJwk0sOnIqh3qUjuXtSy5WP/GRc+QCw5vO184KrDzw40ewqREQkHync5JYydeiR9jZuzg64OTni6uyIq5MDbs4OuDo74uboiKuzA67ODrg7O+Lq9Lf3na6873Tt+GvncsjbcSlFWanKmtNGRKSYsRiGkbOBF4VUXFwcPj4+xMbG4u3tnWvnNQzD3PElIiIiRVh2/n6rOyCXKNiIiIgUDAo3IiIiUqSYHm4++eQTKleujJubG82aNWPTpk233HfPnj1069aNypUrY7FYmDp1av4VKiIiIoWCqeFm4cKFDB06lNGjR7Nt2zYaNmxIhw4dOHv27E33T0pKomrVqkyYMIHAQA0SFRERkRuZGm4++OADBgwYQP/+/albty7Tp0/Hw8OD2bNn33T/Jk2aMHnyZHr16oWrq2s+VysiIiKFgWnhJjU1la1bt9K+fftrxTg40L59ezZs2JBr10lJSSEuLi7Th4iIiBRdpoWbc+fOYbVaCQgIyNQeEBBAVFRUrl1n/Pjx+Pj4ZHwEBQXl2rlFRESk4DF9QHFeGz58OLGxsRkfJ06cMLskERERyUOmzVDs5+eHo6Mj0dHRmdqjo6NzdbCwq6urxueIiIgUI6b13Li4uNC4cWPCw8Mz2mw2G+Hh4bRo0cKsskRERKSQM3VtqaFDh9KvXz/CwsJo2rQpU6dOJTExkf79+wPQt29fypcvz/jx4wH7IOS9e/dmbJ86dYqIiAhKlChB9erVTfs8REREpOAwNdz07NmTmJgYRo0aRVRUFCEhISxfvjxjkPHx48dxcLjWuXT69GlCQ0MzXr///vu8//77tGnThtWrV+d3+SIiIlIAaeFMERERKfC0cKaIiIgUW6beljLD1Y4qTeYnIiJSeFz9u52VG07FLtzEx8cDaDI/ERGRQig+Ph4fH59/3KfYjbmx2WycPn0aLy8vLBaL2eUUSHFxcQQFBXHixAmNSyoA9P0oWPT9KHj0PSlY8ur7YRgG8fHxlCtXLtPDRjdT7HpuHBwcqFChgtllFAre3t76RVGA6PtRsOj7UfDoe1Kw5MX343Y9NldpQLGIiIgUKQo3IiIiUqQo3MgNXF1dGT16tNbkKiD0/ShY9P0oePQ9KVgKwvej2A0oFhERkaJNPTciIiJSpCjciIiISJGicCMiIiJFisKNiIiIFCkKN5Jh/PjxNGnSBC8vL/z9/encuTORkZFmlyXAhAkTsFgsDB482OxSirVTp07x5JNPUrp0adzd3WnQoAFbtmwxu6xiyWq18tZbb1GlShXc3d2pVq0aY8eOzdK6Q3Ln1q5dS6dOnShXrhwWi4Uffvgh0/uGYTBq1CjKli2Lu7s77du35+DBg/lWn8KNZFizZg0DBw7kzz//ZMWKFaSlpXH//feTmJhodmnF2ubNm/n8888JDg42u5Ri7eLFi9x11104Ozvzv//9j7179zJlyhRKlSpldmnF0sSJE/nss8+YNm0a+/btY+LEiUyaNIl///vfZpdWLCQmJtKwYUM++eSTm74/adIkPv74Y6ZPn87GjRvx9PSkQ4cOJCcn50t9ehRcbikmJgZ/f3/WrFnD3XffbXY5xVJCQgKNGjXi008/5d133yUkJISpU6eaXVaxNGzYMNavX8+6devMLkWAhx9+mICAAGbNmpXR1q1bN9zd3fnqq69MrKz4sVgsfP/993Tu3Bmw99qUK1eOV155hVdffRWA2NhYAgICmDNnDr169crzmtRzI7cUGxsLgK+vr8mVFF8DBw6kY8eOtG/f3uxSir2lS5cSFhZG9+7d8ff3JzQ0lJkzZ5pdVrHVsmVLwsPDOXDgAAA7duzg999/58EHHzS5Mvnrr7+IiorK9HvLx8eHZs2asWHDhnypodgtnClZY7PZGDx4MHfddRf169c3u5xiacGCBWzbto3NmzebXYoAR44c4bPPPmPo0KG8+eabbN68mZdeegkXFxf69etndnnFzrBhw4iLi6N27do4OjpitVp57733eOKJJ8wurdiLiooCICAgIFN7QEBAxnt5TeFGbmrgwIHs3r2b33//3exSiqUTJ07w8ssvs2LFCtzc3MwuR7AH/rCwMMaNGwdAaGgou3fvZvr06Qo3Jvjmm2/4+uuvmTdvHvXq1SMiIoLBgwdTrlw5fT9Et6XkRoMGDeKnn37it99+o0KFCmaXUyxt3bqVs2fP0qhRI5ycnHBycmLNmjV8/PHHODk5YbVazS6x2Clbtix169bN1FanTh2OHz9uUkXF22uvvcawYcPo1asXDRo0oE+fPgwZMoTx48ebXVqxFxgYCEB0dHSm9ujo6Iz38prCjWQwDINBgwbx/fffs2rVKqpUqWJ2ScVWu3bt2LVrFxERERkfYWFhPPHEE0RERODo6Gh2icXOXXfddcPUCAcOHKBSpUomVVS8JSUl4eCQ+U+Yo6MjNpvNpIrkqipVqhAYGEh4eHhGW1xcHBs3bqRFixb5UoNuS0mGgQMHMm/ePJYsWYKXl1fGvVEfHx/c3d1Nrq548fLyumGsk6enJ6VLl9YYKJMMGTKEli1bMm7cOHr06MGmTZuYMWMGM2bMMLu0YqlTp0689957VKxYkXr16rF9+3Y++OADnn76abNLKxYSEhI4dOhQxuu//vqLiIgIfH19qVixIoMHD+bdd9+lRo0aVKlShbfeeoty5cplPFGV5wyRK4CbfnzxxRdmlyaGYbRp08Z4+eWXzS6jWPvxxx+N+vXrG66urkbt2rWNGTNmmF1SsRUXF2e8/PLLRsWKFQ03NzejatWqxogRI4yUlBSzSysWfvvtt5v+vejXr59hGIZhs9mMt956ywgICDBcXV2Ndu3aGZGRkflWn+a5ERERkSJFY25ERESkSFG4ERERkSJF4UZERESKFIUbERERKVIUbkRERKRIUbgRERGRIkXhRkRERIoUhRsREREpUhRuRKTYW716NRaLhUuXLpldiojkAoUbERERKVIUbkRERKRIUbgREdPZbDbGjx9PlSpVcHd3p2HDhixatAi4dsto2bJlBAcH4+bmRvPmzdm9e3emcyxevJh69erh6upK5cqVmTJlSqb3U1JSeOONNwgKCsLV1ZXq1asza9asTPts3bqVsLAwPDw8aNmyJZGRkXn7iYtInlC4ERHTjR8/nrlz5zJ9+nT27NnDkCFDePLJJ1mzZk3GPq+99hpTpkxh8+bNlClThk6dOpGWlgbYQ0mPHj3o1asXu3bt4u233+att95izpw5Gcf37duX+fPn8/HHH7Nv3z4+//xzSpQokamOESNGMGXKFLZs2YKTkxNPP/10vnz+IpK7tCq4iJgqJSUFX19fVq5cSYsWLTLan3nmGZKSknj22We59957WbBgAT179gTgwoULVKhQgTlz5tCjRw+eeOIJYmJi+PXXXzOOf/3111m2bBl79uzhwIED1KpVixUrVtC+ffsbali9ejX33nsvK1eupF27dgD8/PPPdOzYkcuXL+Pm5pbHXwURyU3quRERUx06dIikpCTuu+8+SpQokfExd+5cDh8+nLHf9cHH19eXWrVqsW/fPgD27dvHXXfdlem8d911FwcPHsRqtRIREYGjoyNt2rT5x1qCg4MztsuWLQvA2bNn7/hzFJH85WR2ASJSvCUkJACwbNkyypcvn+k9V1fXTAEnp9zd3bO0n7Ozc8a2xWIB7OOBRKRwUc+NiJiqbt26uLq6cvz4capXr57pIygoKGO/P//8M2P74sWLHDhwgDp16gBQp04d1q9fn+m869evp2bNmjg6OtKgQQNsNlumMTwiUnSp50ZETOXl5cWrr77KkCFDsNlstGrVitjYWNavX4+3tzeVKlUC4J133qF06dIEBAQwYsQI/Pz86Ny5MwCvvPIKTZo0YezYsfTs2ZMNGzYwbdo0Pv30UwAqV65Mv379ePrpp/n4449p2LAhx44d4+zZs/To0cOsT11E8ojCjYiYbuzYsZQpU4bx48dz5MgRSpYsSaNGjXjzzTczbgtNmDCBl19+mYMHDxISEsKPP/6Ii4sLAI0aNeKbb75h1KhRjB07lrJly/LOO+/w1FNPZVzjs88+48033+SFF17g/PnzVKxYkTfffNOMT1dE8pielhKRAu3qk0wXL16kZMmSZpcjIoWAxtyIiIhIkaJwIyIiIkWKbkuJiIhIkaKeGxERESlSFG5ERESkSFG4ERERkSJF4UZERESKFIUbERERKVIUbkRERKRIUbgRERGRIkXhRkRERIqU/wfW4S2MTVKJ2QAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure()\n",
+    "plt.plot(epoch_list, train_loss_list, label='loss (train)')\n",
+    "plt.xlabel(\"epoch\")     # x軸ラベル\n",
+    "plt.ylabel(\"loss\")      # y軸ラベル\n",
+    "plt.legend()            # 凡例\n",
+    "plt.show()\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.plot(epoch_list, train_accuracy_list, label='accuracy (train)')\n",
+    "plt.plot(epoch_list, test_accuracy_list, label='accuracy (test)')\n",
+    "plt.xlabel(\"epoch\")     # x軸ラベル\n",
+    "plt.ylabel(\"accuracy\")  # y軸ラベル\n",
+    "plt.legend()            # 凡例\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XJiDB3Is3_sf"
+   },
+   "source": [
+    "## 課題\n",
+    "1. エポック数を50にして学習推移と認識率の変化について確認しよう\n",
+    "2. 活性化関数をReLUに変更して認識性能の変化について確認しよう\n",
+    "3. 最も高い認識率となるようにパラメータを探索しよう"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "04_mlp_mnist.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
## 概要
第9回 [MLPによる多クラス分類（MNIST）](https://github.com/machine-perception-robotics-group/MPRGDeepLearningLectureNotebook/blob/master/01_dnn_scratch/mlp_mnist.ipynb)

上記のnotebookでMNISTがダウンロードできません．
そのため，torchvisionのMNISTを利用する方法に変更しています．
 
## 変更点

* `該当notebook`の編集
MNISTのダウンロード，読み込み部分のプログラムを変更．
```python
import torchvision
train_data = torchvision.datasets.MNIST(root="./", train=True, download=True)
test_data = torchvision.datasets.MNIST(root="./", train=False, download=True)

train_data = torchvision.datasets.MNIST(root="./", train=True, download=True)
test_data = torchvision.datasets.MNIST(root="./", train=False, download=True)

x_train = train_data.data.numpy().reshape(-1, 784)
y_train = train_data.targets.numpy()
x_test = test_data.data.numpy().reshape(-1, 784)
y_test = test_data.targets.numpy()  

print(x_train.shape, y_train.shape)
print(x_test.shape, y_test.shape)

```