### PR TITLE
MNISTデータセットがダウンロードできないバグの修正 (CNN, MNIST編)

### DIFF
--- a/01_dnn_scratch/cnn_mnist.ipynb
+++ b/01_dnn_scratch/cnn_mnist.ipynb
@@ -1,1 +1,538 @@
-{"cells":[{"cell_type":"markdown","metadata":{"id":"HoYBRwoQ4CPO"},"source":["# CNNによる画像認識（MNIST, Numpy実装）\n","---\n","\n","## 目的\n","畳み込みニューラルネットワーク (Convolutional Neural Network; CNN) を用いてCIFAR10データセットに対する物体認識を行う．\n","\n","\n","\n","## モジュールのインポート\n","プログラムの実行に必要なモジュールをインポートします．"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"Bi7cHWI44CPP"},"outputs":[],"source":["import numpy as np\n","import matplotlib.pyplot as plt\n","import gzip\n","from time import time"]},{"cell_type":"markdown","metadata":{"id":"hgpU02Pg4CPS"},"source":["## データセットのダウンロードと読み込みと学習サンプルの削減\n","\n","\n","まずはじめに，`wget`コマンドを使用して，MNISTデータセットをダウンロードします．"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"30lAJ-LS4CPU"},"outputs":[],"source":["!wget -q http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz -O train-images-idx3-ubyte.gz\n","!wget -q http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz -O train-labels-idx1-ubyte.gz\n","!wget -q http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz -O t10k-images-idx3-ubyte.gz\n","!wget -q http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz -O t10k-labels-idx1-ubyte.gz"]},{"cell_type":"markdown","metadata":{"id":"cXhCR13e4CPX"},"source":["次に，ダウンロードしたファイルからデータを読み込みます．詳細は前回までのプログラムを確認してください．\n","\n","今回は2次元の画像データとしてMNISTデータセットを扱うため，\n","データを`(チャンネル, 縦，横)`の形に並べ替えます．"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"OyQB7loc4CPY"},"outputs":[],"source":["# load images\n","with gzip.open('train-images-idx3-ubyte.gz', 'rb') as f:\n","    x_train = np.frombuffer(f.read(), np.uint8, offset=16)\n","x_train = x_train.reshape(-1, 784)\n","\n","with gzip.open('t10k-images-idx3-ubyte.gz', 'rb') as f:\n","    x_test = np.frombuffer(f.read(), np.uint8, offset=16)\n","x_test = x_test.reshape(-1, 784)\n","\n","with gzip.open('train-labels-idx1-ubyte.gz', 'rb') as f:\n","    y_train = np.frombuffer(f.read(), np.uint8, offset=8)\n","\n","with gzip.open('t10k-labels-idx1-ubyte.gz', 'rb') as f:\n","    y_test = np.frombuffer(f.read(), np.uint8, offset=8)\n","\n","x_train = x_train.reshape(-1, 1, 28, 28)\n","x_test = x_test.reshape(-1, 1, 28, 28)\n","\n","print(x_train.shape, y_train.shape)\n","print(x_test.shape, y_test.shape)"]},{"cell_type":"markdown","metadata":{"id":"ep_qaVu44CPb"},"source":["## ネットワークモデルの定義\n","次に，CNNを定義します．\n","\n","まずはじめに，ネットワークの定義に必要な関数を定義します．"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"mQ3OfRGA4CPe"},"outputs":[],"source":["def relu(x):\n","    return np.maximum(0, x)\n","\n","def relu_grad(x):\n","    grad = np.zeros(x.shape)\n","    grad[x > 0] = 1\n","    return grad\n","\n","def softmax(x):\n","    if x.ndim == 2:\n","        x = x.T\n","        x = x - np.max(x, axis=0)\n","        y = np.exp(x) / np.sum(np.exp(x), axis=0)\n","        return y.T \n","\n","    x = x - np.max(x)\n","    return np.exp(x) / np.sum(np.exp(x))\n","\n","def cross_entropy(y, t):\n","    if y.ndim == 1:\n","        t = t.reshape(1, t.size)\n","        y = y.reshape(1, y.size)\n","\n","    if t.size == y.size:\n","        t = t.argmax(axis=1)\n","\n","    batch_size = y.shape[0]\n","    return -np.sum(np.log(y[np.arange(batch_size), t] + 1e-7)) / batch_size"]},{"cell_type":"markdown","metadata":{"id":"MOHODRmT4CPg"},"source":["`im2col`およびその逆の変換の`col2im`も定義を行います．"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"zlAfEDzS4CPg"},"outputs":[],"source":["def im2col(input_image, kernel_h, kernel_w, stride=1, padding=0):\n","    n, c, h, w = input_image.shape\n","    \n","    dst_h = (h + 2 * padding - kernel_h) // stride + 1\n","    dst_w = (w + 2 * padding - kernel_w) // stride + 1\n","    \n","    image = np.pad(input_image, [(0,0), (0,0), (padding, padding), (padding, padding)], 'constant')\n","    col = np.zeros((n, c, kernel_h, kernel_w, dst_h, dst_w))\n","    \n","    for y in range(kernel_h):\n","        y_max = y + stride * dst_h\n","        for x in range(kernel_w):\n","            x_max = x + stride * dst_w\n","            col[:, :, y, x, :, :] = image[:, :, y:y_max:stride, x:x_max:stride]\n","    \n","    col = col.transpose(0, 4, 5, 1, 2, 3).reshape(n * dst_h * dst_w, -1)\n","    return col\n","\n","def col2im(col, input_shape, kernel_h, kernel_w, stride=1, padding=0):\n","    n, c, h, w = input_shape\n","    out_h = (h + 2 * padding - kernel_h) // stride + 1\n","    out_w = (w + 2 * padding - kernel_w) // stride + 1\n","    col = col.reshape(n, out_h, out_w, c, kernel_h, kernel_w).transpose(0, 3, 4, 5, 1, 2)\n","\n","    img = np.zeros((n, c, h + 2 * padding + stride - 1, w + 2 * padding + stride - 1))\n","    for y in range(kernel_h):\n","        y_max = y + stride * out_h\n","        for x in range(kernel_w):\n","            x_max = x + stride*out_w\n","            img[:, :, y:y_max:stride, x:x_max:stride] += col[:, :, y, x, :, :]\n","\n","    return img[:, :, padding:h + padding, padding:w + padding]"]},{"cell_type":"markdown","metadata":{"id":"cvXj4KPd4CPi"},"source":["畳み込みおよびプーリングの処理は煩雑になってしまうため，関数として定義します．"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"2jE3eO_-4CPj"},"outputs":[],"source":["def conv(x, w, b, stride=1, padding=0):\n","    FN, C, FH, FW = w.shape\n","    N, C, H, W = x.shape\n","\n","    out_h = 1 + int((H + 2 * padding - FH) / stride)\n","    out_w = 1 + int((W + 2 * padding - FW) / stride)\n","\n","    col = im2col(x, FH, FW, stride, padding)\n","    col_w = w.reshape(FN, -1).T\n","\n","    out = np.dot(col, col_w) + b\n","    out = out.reshape(N, out_h, out_w, -1).transpose(0, 3, 1, 2)\n","    \n","    return out, col, col_w\n","\n","def conv_grad(dout, x, col, col_w, w, b, stride=1, padding=0):\n","    FN, C, FH, FW = w.shape\n","    dout = dout.transpose(0, 2, 3, 1).reshape(-1, FN)\n","    \n","    grad_b = np.sum(dout, axis=0)\n","    grad_w = np.dot(col.T, dout)\n","    grad_w = grad_w.transpose(1, 0).reshape(FN, C, FH, FW)\n","    \n","    dcol = np.dot(dout, col_w.T)\n","    dx = col2im(dcol, x.shape, FH, FW, stride, padding)\n","\n","    return dx, grad_w, grad_b\n","    \n","def maxpool(x, pool_size=2, stride=2, padding=0):\n","    N, C, H, W = x.shape\n","    out_h = int(1 + (H - pool_size) / stride)\n","    out_w = int(1 + (W - pool_size) / stride)\n","    \n","    col = im2col(x, pool_size, pool_size, stride, padding)\n","    col = col.reshape(-1, pool_size * pool_size)\n","    \n","    arg_max = np.argmax(col, axis=1)\n","    out = np.max(col, axis=1)\n","    out = out.reshape(N, out_h, out_w, C).transpose(0, 3, 1, 2)\n","\n","    return out, arg_max\n","\n","def maxpool_grad(dout, x, arg_max, p_size=2, stride=2, padding=0):\n","    dout = dout.transpose(0, 2, 3, 1)\n","    pool_size = p_size * p_size\n","\n","    dmax = np.zeros((dout.size, pool_size))\n","    dmax[np.arange(arg_max.size), arg_max.flatten()] = dout.flatten()\n","    dmax = dmax.reshape(dout.shape + (pool_size,)) \n","\n","    dcol = dmax.reshape(dmax.shape[0] * dmax.shape[1] * dmax.shape[2], -1)\n","    dx = col2im(dcol, x.shape, p_size, p_size, stride, padding)\n","\n","    return dx"]},{"cell_type":"markdown","metadata":{"id":"9xxRWeSR4CPl"},"source":["次に，上で定義した関数を用いてネットワークを定義します．\n","ここでは，畳み込み層，中間層，出力層から構成されるCNNとします．\n","\n","入力画像のチャンネル数と，畳み込みのカーネルサイズ，畳み込みのカーネル数を引数として指定します．\n","さらに，中間層，出力層のユニット数は引数として与え，それぞれ`hidden_size`, `output_size`とします．\n","そして，`__init__`関数を用いて，ネットワークのパラメータを初期化します．\n","`w1`, `w2`, `w3`は各層の重みで，`b1`, `b2`, `b3`はバイアスを表しています．\n","重みは`randn`関数で，標準正規分布に従った乱数で生成した値を保有する配列を生成します．\n","バイアスは`zeros`関数を用いて，要素が全て0の配列を生成します．\n","\n","そして，`forward`関数で，データを入力して結果を出力するための演算を定義します．\n","\n","次に，`backward`関数ではパラメータの更新量を計算します．\n","まず，ネットワークの出力結果と教師ラベルから，誤差`dy`を算出します．\n","この時，教師ラベルをone-hotベクトルへ変換し，各ユニットの出力との差を取ることで，`dy`を計算しています．\n","その後，連鎖律に基づいて，出力層から順番に勾配を計算していきます．\n","このとき，パラメータの更新量を`self.grads`へ保存しておきます．\n","\n","最後に`update_parameters`関数で，更新量をもとにパラメータの更新を行います．"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"Uudr8bll4CPl"},"outputs":[],"source":["class CNN:\n","    \n","    def __init__(self, n_channels=1, filter_size=3, num_kernel=64, hidden_size=128, output_size=10, w_std=0.01):\n","        \n","        # convolutional layer\n","        self.w1 = w_std * np.random.randn(num_kernel, n_channels, filter_size, filter_size)\n","        self.b1 = np.zeros(num_kernel)\n","        # hidden layer\n","        pooled_feature_size = int(num_kernel * (28 / 2) * (28 / 2))\n","        self.w2 = w_std * np.random.randn(pooled_feature_size, hidden_size)\n","        self.b2 = np.zeros(hidden_size)\n","        # output layer\n","        self.w3 = w_std * np.random.randn(hidden_size, output_size)\n","        self.b3 = np.zeros(output_size)\n","        # dict. for gradients\n","        self.grads = {}\n","\n","    def forward(self, x):\n","        self.h1, self.h1_col, self.h1_col_w = conv(x, self.w1, self.b1, stride=1, padding=1)\n","        self.h2 = relu(self.h1)\n","        self.h3, self.h3_argmax = maxpool(self.h2, pool_size=2, stride=2, padding=0)\n","        self.h4 = np.dot(self.h3.reshape(self.h2.shape[0], -1), self.w2) + self.b2\n","        self.h5 = relu(self.h4)\n","        self.h6 = np.dot(self.h5, self.w3) + self.b3\n","        self.y = softmax(self.h6)\n","        return self.y\n","        \n","    def backward(self, x, t):\n","        batch_size = x.shape[0]\n","        \n","        # backward #####\n","        self.grads = {}\n","        \n","        t = np.identity(10)[t]\n","        \n","        dy = (self.y - t) / batch_size\n","        \n","        # output layer\n","        d_h5 = np.dot(dy, self.w3.T)\n","        self.grads['w3'] = np.dot(self.h5.T, dy)\n","        self.grads['b3'] = np.sum(dy, axis=0)\n","        \n","        # relu\n","        d_h4 = relu_grad(self.h4) * d_h5\n","        \n","        # hidden layer\n","        d_h3 = np.dot(d_h4, self.w2.T)\n","        self.grads['w2'] = np.dot(self.h3.T, d_h4).reshape(self.w2.shape)\n","        self.grads['b2'] = np.sum(d_h4, axis=0)\n","        \n","        # maxpool\n","        d_h3 = d_h3.reshape(self.h3.shape)\n","        d_h2 = maxpool_grad(d_h3, self.h2, self.h3_argmax, p_size=2, stride=2, padding=0)\n","\n","        # relu\n","        d_h1 = relu_grad(self.h1) * d_h2\n","\n","        # convolution\n","        _, self.grads['w1'], self.grads['b1'] = conv_grad(d_h1, x, self.h1_col, self.h1_col_w, self.w1, self.b2, stride=1, padding=1)\n","\n","    def update_parameters(self, lr=0.1): \n","        self.w1 -= lr * self.grads['w1']\n","        self.b1 -= lr * self.grads['b1']\n","        self.w2 -= lr * self.grads['w2']\n","        self.b2 -= lr * self.grads['b2']\n","        self.w3 -= lr * self.grads['w3']\n","        self.b3 -= lr * self.grads['b3']"]},{"cell_type":"markdown","metadata":{"id":"p58_NRzJ4CPn"},"source":["## ネットワークの作成と学習の準備\n","\n","読み込んだMNISTデータセットと作成したネットワークを用いて，学習を行います．\n","\n","1回の誤差を算出するデータ数（ミニバッチサイズ）を100，学習エポック数を10とします．\n","\n","学習データは毎回ランダムに決定するため，numpyの`permutation`という関数を利用します．\n","各更新において，学習用データと教師データをそれぞれ`x_batch`と`y_batch`とします．\n","学習モデルに`x_batch`を与えて，`h`を取得します．\n","取得した`h`は精度および誤差を算出するための関数へと入力され，値を保存します．\n","そして，誤差を`backward`関数で逆伝播し，`update_parameters`でネットワークの更新を行います．"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"kbEJ-xH74CPn"},"outputs":[],"source":["model = CNN(n_channels=1, filter_size=3, num_kernel=64, hidden_size=256, output_size=10)"]},{"cell_type":"markdown","metadata":{"id":"ituZSlEU4CPp"},"source":["## 学習\n","学習したネットワークを用いて，テストデータに対する認識律の確認を行います．"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"k7wCwLWr4CPq"},"outputs":[],"source":["def softmax_cross_entropy(x, t):\n","    y = softmax(x)\n","    return cross_entropy(y, t)\n","\n","def multiclass_classification_accuracy(pred, true):\n","    clf_res = np.argmax(pred, axis=1)\n","    return np.sum(clf_res == true).astype(np.float32)\n","\n","num_train_data = x_train.shape[0]\n","batch_size = 100\n","epoch_num = 10\n","\n","iteration = 1\n","start = time()\n","for epoch in range(1, epoch_num + 1):\n","    sum_accuracy = 0.0\n","    sum_loss= 0.0\n","    \n","    perm = np.random.permutation(num_train_data)\n","    for i in range(0, num_train_data, batch_size):\n","        x_batch = x_train[perm[i:i+batch_size]]\n","        y_batch = y_train[perm[i:i+batch_size]]\n","        \n","        h = model.forward(x_batch)\n","        sum_accuracy += multiclass_classification_accuracy(h, y_batch)\n","        loss = softmax_cross_entropy(h, y_batch)\n","        sum_loss += loss\n","        \n","        model.backward(x_batch, y_batch)\n","        model.update_parameters(lr=0.1)\n","        \n","        if iteration % 100 == 0:\n","            print(\"iteration: {}, loss: {}\".format(iteration, loss))\n","\n","        iteration += 1\n","\n","    print(\"epoch: {}, mean loss: {}, mean accuracy: {}, elapsed time: {}\".format(epoch,\n","                                                                                 sum_loss / num_train_data,\n","                                                                                 sum_accuracy / num_train_data,\n","                                                                                 time() - start))"]},{"cell_type":"markdown","metadata":{"id":"hBh6HKN74CPs"},"source":["## テスト\n","学習したネットワークを用いて，テストデータに対する認識率の確認を行います．"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"kk1Eufsa4CPs"},"outputs":[],"source":["count = 0\n","num_test_data = x_test.shape[0]\n","\n","for i in range(num_test_data):\n","    x = np.array([x_test[i]], dtype=np.float32)\n","    t = y_test[i]\n","    y = model.forward(x)\n","    pred = np.argmax(y.flatten())\n","    \n","    if pred == t:\n","        count += 1\n","\n","print(\"test accuracy: {}\".format(count / num_test_data))"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"x6KSQusZZNjW"},"outputs":[],"source":[]}],"metadata":{"accelerator":"GPU","colab":{"collapsed_sections":[],"name":"09_cnn_mnist.ipynb","provenance":[{"file_id":"https://github.com/machine-perception-robotics-group/MPRGDeepLearningLectureNotebook/blob/master/01_dnn_scratch/09_cnn.ipynb","timestamp":1606132171505}]},"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"},"language_info":{"codemirror_mode":{"name":"ipython","version":3},"file_extension":".py","mimetype":"text/x-python","name":"python","nbconvert_exporter":"python","pygments_lexer":"ipython3","version":"3.5.2"}},"nbformat":4,"nbformat_minor":0}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HoYBRwoQ4CPO"
+   },
+   "source": [
+    "# CNNによる画像認識（MNIST, Numpy実装）\n",
+    "---\n",
+    "\n",
+    "## 目的\n",
+    "畳み込みニューラルネットワーク (Convolutional Neural Network; CNN) を用いてCIFAR10データセットに対する物体認識を行う．\n",
+    "\n",
+    "\n",
+    "\n",
+    "## モジュールのインポート\n",
+    "プログラムの実行に必要なモジュールをインポートします．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Bi7cHWI44CPP"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import gzip\n",
+    "from time import time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hgpU02Pg4CPS"
+   },
+   "source": [
+    "## データセットのダウンロードと読み込みと学習サンプルの削減\n",
+    "\n",
+    "\n",
+    "torchvisionのMNISTを利用します．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "30lAJ-LS4CPU"
+   },
+   "outputs": [],
+   "source": [
+    "import torchvision\n",
+    "train_data = torchvision.datasets.MNIST(root=\"./\", train=True, download=True)\n",
+    "test_data = torchvision.datasets.MNIST(root=\"./\", train=False, download=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cXhCR13e4CPX"
+   },
+   "source": [
+    "次に，ダウンロードしたファイルからデータを読み込みます．詳細は前回までのプログラムを確認してください．\n",
+    "\n",
+    "今回は2次元の画像データとしてMNISTデータセットを扱うため，\n",
+    "データを`(チャンネル, 縦，横)`の形に並べ替えます．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "OyQB7loc4CPY"
+   },
+   "outputs": [],
+   "source": [
+    "train_data = torchvision.datasets.MNIST(root=\"./\", train=True, download=True)\n",
+    "test_data = torchvision.datasets.MNIST(root=\"./\", train=False, download=True)\n",
+    "\n",
+    "x_train = train_data.data.numpy().reshape(-1, 784)\n",
+    "y_train = train_data.targets.numpy()\n",
+    "x_test = test_data.data.numpy().reshape(-1, 784)\n",
+    "y_test = test_data.targets.numpy() \n",
+    "\n",
+    "x_train = x_train.reshape(-1, 1, 28, 28)\n",
+    "x_test = x_test.reshape(-1, 1, 28, 28)\n",
+    "\n",
+    "print(x_train.shape, y_train.shape)\n",
+    "print(x_test.shape, y_test.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ep_qaVu44CPb"
+   },
+   "source": [
+    "## ネットワークモデルの定義\n",
+    "次に，CNNを定義します．\n",
+    "\n",
+    "まずはじめに，ネットワークの定義に必要な関数を定義します．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "mQ3OfRGA4CPe"
+   },
+   "outputs": [],
+   "source": [
+    "def relu(x):\n",
+    "    return np.maximum(0, x)\n",
+    "\n",
+    "def relu_grad(x):\n",
+    "    grad = np.zeros(x.shape)\n",
+    "    grad[x > 0] = 1\n",
+    "    return grad\n",
+    "\n",
+    "def softmax(x):\n",
+    "    if x.ndim == 2:\n",
+    "        x = x.T\n",
+    "        x = x - np.max(x, axis=0)\n",
+    "        y = np.exp(x) / np.sum(np.exp(x), axis=0)\n",
+    "        return y.T \n",
+    "\n",
+    "    x = x - np.max(x)\n",
+    "    return np.exp(x) / np.sum(np.exp(x))\n",
+    "\n",
+    "def cross_entropy(y, t):\n",
+    "    if y.ndim == 1:\n",
+    "        t = t.reshape(1, t.size)\n",
+    "        y = y.reshape(1, y.size)\n",
+    "\n",
+    "    if t.size == y.size:\n",
+    "        t = t.argmax(axis=1)\n",
+    "\n",
+    "    batch_size = y.shape[0]\n",
+    "    return -np.sum(np.log(y[np.arange(batch_size), t] + 1e-7)) / batch_size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MOHODRmT4CPg"
+   },
+   "source": [
+    "`im2col`およびその逆の変換の`col2im`も定義を行います．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zlAfEDzS4CPg"
+   },
+   "outputs": [],
+   "source": [
+    "def im2col(input_image, kernel_h, kernel_w, stride=1, padding=0):\n",
+    "    n, c, h, w = input_image.shape\n",
+    "    \n",
+    "    dst_h = (h + 2 * padding - kernel_h) // stride + 1\n",
+    "    dst_w = (w + 2 * padding - kernel_w) // stride + 1\n",
+    "    \n",
+    "    image = np.pad(input_image, [(0,0), (0,0), (padding, padding), (padding, padding)], 'constant')\n",
+    "    col = np.zeros((n, c, kernel_h, kernel_w, dst_h, dst_w))\n",
+    "    \n",
+    "    for y in range(kernel_h):\n",
+    "        y_max = y + stride * dst_h\n",
+    "        for x in range(kernel_w):\n",
+    "            x_max = x + stride * dst_w\n",
+    "            col[:, :, y, x, :, :] = image[:, :, y:y_max:stride, x:x_max:stride]\n",
+    "    \n",
+    "    col = col.transpose(0, 4, 5, 1, 2, 3).reshape(n * dst_h * dst_w, -1)\n",
+    "    return col\n",
+    "\n",
+    "def col2im(col, input_shape, kernel_h, kernel_w, stride=1, padding=0):\n",
+    "    n, c, h, w = input_shape\n",
+    "    out_h = (h + 2 * padding - kernel_h) // stride + 1\n",
+    "    out_w = (w + 2 * padding - kernel_w) // stride + 1\n",
+    "    col = col.reshape(n, out_h, out_w, c, kernel_h, kernel_w).transpose(0, 3, 4, 5, 1, 2)\n",
+    "\n",
+    "    img = np.zeros((n, c, h + 2 * padding + stride - 1, w + 2 * padding + stride - 1))\n",
+    "    for y in range(kernel_h):\n",
+    "        y_max = y + stride * out_h\n",
+    "        for x in range(kernel_w):\n",
+    "            x_max = x + stride*out_w\n",
+    "            img[:, :, y:y_max:stride, x:x_max:stride] += col[:, :, y, x, :, :]\n",
+    "\n",
+    "    return img[:, :, padding:h + padding, padding:w + padding]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cvXj4KPd4CPi"
+   },
+   "source": [
+    "畳み込みおよびプーリングの処理は煩雑になってしまうため，関数として定義します．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2jE3eO_-4CPj"
+   },
+   "outputs": [],
+   "source": [
+    "def conv(x, w, b, stride=1, padding=0):\n",
+    "    FN, C, FH, FW = w.shape\n",
+    "    N, C, H, W = x.shape\n",
+    "\n",
+    "    out_h = 1 + int((H + 2 * padding - FH) / stride)\n",
+    "    out_w = 1 + int((W + 2 * padding - FW) / stride)\n",
+    "\n",
+    "    col = im2col(x, FH, FW, stride, padding)\n",
+    "    col_w = w.reshape(FN, -1).T\n",
+    "\n",
+    "    out = np.dot(col, col_w) + b\n",
+    "    out = out.reshape(N, out_h, out_w, -1).transpose(0, 3, 1, 2)\n",
+    "    \n",
+    "    return out, col, col_w\n",
+    "\n",
+    "def conv_grad(dout, x, col, col_w, w, b, stride=1, padding=0):\n",
+    "    FN, C, FH, FW = w.shape\n",
+    "    dout = dout.transpose(0, 2, 3, 1).reshape(-1, FN)\n",
+    "    \n",
+    "    grad_b = np.sum(dout, axis=0)\n",
+    "    grad_w = np.dot(col.T, dout)\n",
+    "    grad_w = grad_w.transpose(1, 0).reshape(FN, C, FH, FW)\n",
+    "    \n",
+    "    dcol = np.dot(dout, col_w.T)\n",
+    "    dx = col2im(dcol, x.shape, FH, FW, stride, padding)\n",
+    "\n",
+    "    return dx, grad_w, grad_b\n",
+    "    \n",
+    "def maxpool(x, pool_size=2, stride=2, padding=0):\n",
+    "    N, C, H, W = x.shape\n",
+    "    out_h = int(1 + (H - pool_size) / stride)\n",
+    "    out_w = int(1 + (W - pool_size) / stride)\n",
+    "    \n",
+    "    col = im2col(x, pool_size, pool_size, stride, padding)\n",
+    "    col = col.reshape(-1, pool_size * pool_size)\n",
+    "    \n",
+    "    arg_max = np.argmax(col, axis=1)\n",
+    "    out = np.max(col, axis=1)\n",
+    "    out = out.reshape(N, out_h, out_w, C).transpose(0, 3, 1, 2)\n",
+    "\n",
+    "    return out, arg_max\n",
+    "\n",
+    "def maxpool_grad(dout, x, arg_max, p_size=2, stride=2, padding=0):\n",
+    "    dout = dout.transpose(0, 2, 3, 1)\n",
+    "    pool_size = p_size * p_size\n",
+    "\n",
+    "    dmax = np.zeros((dout.size, pool_size))\n",
+    "    dmax[np.arange(arg_max.size), arg_max.flatten()] = dout.flatten()\n",
+    "    dmax = dmax.reshape(dout.shape + (pool_size,)) \n",
+    "\n",
+    "    dcol = dmax.reshape(dmax.shape[0] * dmax.shape[1] * dmax.shape[2], -1)\n",
+    "    dx = col2im(dcol, x.shape, p_size, p_size, stride, padding)\n",
+    "\n",
+    "    return dx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9xxRWeSR4CPl"
+   },
+   "source": [
+    "次に，上で定義した関数を用いてネットワークを定義します．\n",
+    "ここでは，畳み込み層，中間層，出力層から構成されるCNNとします．\n",
+    "\n",
+    "入力画像のチャンネル数と，畳み込みのカーネルサイズ，畳み込みのカーネル数を引数として指定します．\n",
+    "さらに，中間層，出力層のユニット数は引数として与え，それぞれ`hidden_size`, `output_size`とします．\n",
+    "そして，`__init__`関数を用いて，ネットワークのパラメータを初期化します．\n",
+    "`w1`, `w2`, `w3`は各層の重みで，`b1`, `b2`, `b3`はバイアスを表しています．\n",
+    "重みは`randn`関数で，標準正規分布に従った乱数で生成した値を保有する配列を生成します．\n",
+    "バイアスは`zeros`関数を用いて，要素が全て0の配列を生成します．\n",
+    "\n",
+    "そして，`forward`関数で，データを入力して結果を出力するための演算を定義します．\n",
+    "\n",
+    "次に，`backward`関数ではパラメータの更新量を計算します．\n",
+    "まず，ネットワークの出力結果と教師ラベルから，誤差`dy`を算出します．\n",
+    "この時，教師ラベルをone-hotベクトルへ変換し，各ユニットの出力との差を取ることで，`dy`を計算しています．\n",
+    "その後，連鎖律に基づいて，出力層から順番に勾配を計算していきます．\n",
+    "このとき，パラメータの更新量を`self.grads`へ保存しておきます．\n",
+    "\n",
+    "最後に`update_parameters`関数で，更新量をもとにパラメータの更新を行います．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Uudr8bll4CPl"
+   },
+   "outputs": [],
+   "source": [
+    "class CNN:\n",
+    "    \n",
+    "    def __init__(self, n_channels=1, filter_size=3, num_kernel=64, hidden_size=128, output_size=10, w_std=0.01):\n",
+    "        \n",
+    "        # convolutional layer\n",
+    "        self.w1 = w_std * np.random.randn(num_kernel, n_channels, filter_size, filter_size)\n",
+    "        self.b1 = np.zeros(num_kernel)\n",
+    "        # hidden layer\n",
+    "        pooled_feature_size = int(num_kernel * (28 / 2) * (28 / 2))\n",
+    "        self.w2 = w_std * np.random.randn(pooled_feature_size, hidden_size)\n",
+    "        self.b2 = np.zeros(hidden_size)\n",
+    "        # output layer\n",
+    "        self.w3 = w_std * np.random.randn(hidden_size, output_size)\n",
+    "        self.b3 = np.zeros(output_size)\n",
+    "        # dict. for gradients\n",
+    "        self.grads = {}\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        self.h1, self.h1_col, self.h1_col_w = conv(x, self.w1, self.b1, stride=1, padding=1)\n",
+    "        self.h2 = relu(self.h1)\n",
+    "        self.h3, self.h3_argmax = maxpool(self.h2, pool_size=2, stride=2, padding=0)\n",
+    "        self.h4 = np.dot(self.h3.reshape(self.h2.shape[0], -1), self.w2) + self.b2\n",
+    "        self.h5 = relu(self.h4)\n",
+    "        self.h6 = np.dot(self.h5, self.w3) + self.b3\n",
+    "        self.y = softmax(self.h6)\n",
+    "        return self.y\n",
+    "        \n",
+    "    def backward(self, x, t):\n",
+    "        batch_size = x.shape[0]\n",
+    "        \n",
+    "        # backward #####\n",
+    "        self.grads = {}\n",
+    "        \n",
+    "        t = np.identity(10)[t]\n",
+    "        \n",
+    "        dy = (self.y - t) / batch_size\n",
+    "        \n",
+    "        # output layer\n",
+    "        d_h5 = np.dot(dy, self.w3.T)\n",
+    "        self.grads['w3'] = np.dot(self.h5.T, dy)\n",
+    "        self.grads['b3'] = np.sum(dy, axis=0)\n",
+    "        \n",
+    "        # relu\n",
+    "        d_h4 = relu_grad(self.h4) * d_h5\n",
+    "        \n",
+    "        # hidden layer\n",
+    "        d_h3 = np.dot(d_h4, self.w2.T)\n",
+    "        self.grads['w2'] = np.dot(self.h3.T, d_h4).reshape(self.w2.shape)\n",
+    "        self.grads['b2'] = np.sum(d_h4, axis=0)\n",
+    "        \n",
+    "        # maxpool\n",
+    "        d_h3 = d_h3.reshape(self.h3.shape)\n",
+    "        d_h2 = maxpool_grad(d_h3, self.h2, self.h3_argmax, p_size=2, stride=2, padding=0)\n",
+    "\n",
+    "        # relu\n",
+    "        d_h1 = relu_grad(self.h1) * d_h2\n",
+    "\n",
+    "        # convolution\n",
+    "        _, self.grads['w1'], self.grads['b1'] = conv_grad(d_h1, x, self.h1_col, self.h1_col_w, self.w1, self.b2, stride=1, padding=1)\n",
+    "\n",
+    "    def update_parameters(self, lr=0.1): \n",
+    "        self.w1 -= lr * self.grads['w1']\n",
+    "        self.b1 -= lr * self.grads['b1']\n",
+    "        self.w2 -= lr * self.grads['w2']\n",
+    "        self.b2 -= lr * self.grads['b2']\n",
+    "        self.w3 -= lr * self.grads['w3']\n",
+    "        self.b3 -= lr * self.grads['b3']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "p58_NRzJ4CPn"
+   },
+   "source": [
+    "## ネットワークの作成と学習の準備\n",
+    "\n",
+    "読み込んだMNISTデータセットと作成したネットワークを用いて，学習を行います．\n",
+    "\n",
+    "1回の誤差を算出するデータ数（ミニバッチサイズ）を100，学習エポック数を10とします．\n",
+    "\n",
+    "学習データは毎回ランダムに決定するため，numpyの`permutation`という関数を利用します．\n",
+    "各更新において，学習用データと教師データをそれぞれ`x_batch`と`y_batch`とします．\n",
+    "学習モデルに`x_batch`を与えて，`h`を取得します．\n",
+    "取得した`h`は精度および誤差を算出するための関数へと入力され，値を保存します．\n",
+    "そして，誤差を`backward`関数で逆伝播し，`update_parameters`でネットワークの更新を行います．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "kbEJ-xH74CPn"
+   },
+   "outputs": [],
+   "source": [
+    "model = CNN(n_channels=1, filter_size=3, num_kernel=64, hidden_size=256, output_size=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ituZSlEU4CPp"
+   },
+   "source": [
+    "## 学習\n",
+    "学習したネットワークを用いて，テストデータに対する認識律の確認を行います．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "k7wCwLWr4CPq"
+   },
+   "outputs": [],
+   "source": [
+    "def softmax_cross_entropy(x, t):\n",
+    "    y = softmax(x)\n",
+    "    return cross_entropy(y, t)\n",
+    "\n",
+    "def multiclass_classification_accuracy(pred, true):\n",
+    "    clf_res = np.argmax(pred, axis=1)\n",
+    "    return np.sum(clf_res == true).astype(np.float32)\n",
+    "\n",
+    "num_train_data = x_train.shape[0]\n",
+    "batch_size = 100\n",
+    "epoch_num = 10\n",
+    "\n",
+    "iteration = 1\n",
+    "start = time()\n",
+    "for epoch in range(1, epoch_num + 1):\n",
+    "    sum_accuracy = 0.0\n",
+    "    sum_loss= 0.0\n",
+    "    \n",
+    "    perm = np.random.permutation(num_train_data)\n",
+    "    for i in range(0, num_train_data, batch_size):\n",
+    "        x_batch = x_train[perm[i:i+batch_size]]\n",
+    "        y_batch = y_train[perm[i:i+batch_size]]\n",
+    "        \n",
+    "        h = model.forward(x_batch)\n",
+    "        sum_accuracy += multiclass_classification_accuracy(h, y_batch)\n",
+    "        loss = softmax_cross_entropy(h, y_batch)\n",
+    "        sum_loss += loss\n",
+    "        \n",
+    "        model.backward(x_batch, y_batch)\n",
+    "        model.update_parameters(lr=0.1)\n",
+    "        \n",
+    "        if iteration % 100 == 0:\n",
+    "            print(\"iteration: {}, loss: {}\".format(iteration, loss))\n",
+    "\n",
+    "        iteration += 1\n",
+    "\n",
+    "    print(\"epoch: {}, mean loss: {}, mean accuracy: {}, elapsed time: {}\".format(epoch,\n",
+    "                                                                                 sum_loss / num_train_data,\n",
+    "                                                                                 sum_accuracy / num_train_data,\n",
+    "                                                                                 time() - start))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hBh6HKN74CPs"
+   },
+   "source": [
+    "## テスト\n",
+    "学習したネットワークを用いて，テストデータに対する認識率の確認を行います．"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "kk1Eufsa4CPs"
+   },
+   "outputs": [],
+   "source": [
+    "count = 0\n",
+    "num_test_data = x_test.shape[0]\n",
+    "\n",
+    "for i in range(num_test_data):\n",
+    "    x = np.array([x_test[i]], dtype=np.float32)\n",
+    "    t = y_test[i]\n",
+    "    y = model.forward(x)\n",
+    "    pred = np.argmax(y.flatten())\n",
+    "    \n",
+    "    if pred == t:\n",
+    "        count += 1\n",
+    "\n",
+    "print(\"test accuracy: {}\".format(count / num_test_data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "x6KSQusZZNjW"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "09_cnn_mnist.ipynb",
+   "provenance": [
+    {
+     "file_id": "https://github.com/machine-perception-robotics-group/MPRGDeepLearningLectureNotebook/blob/master/01_dnn_scratch/09_cnn.ipynb",
+     "timestamp": 1606132171505
+    }
+   ]
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## 概要
[CNNによる画像認識（MNIST, Numpy実装）](https://github.com/machine-perception-robotics-group/MPRGDeepLearningLectureNotebook/blob/master/01_dnn_scratch/cnn_mnist.ipynb)

上記のnotebookでMNISTがダウンロードできません．
そのため，torchvisionのMNISTを利用する方法に変更しています．
 
## 変更点

* `該当notebook`の編集
MNISTのダウンロード，読み込み部分のプログラムを変更．
```python
import torchvision
train_data = torchvision.datasets.MNIST(root="./", train=True, download=True)
test_data = torchvision.datasets.MNIST(root="./", train=False, download=True)

x_train = train_data.data.numpy().reshape(-1, 784)
y_train = train_data.targets.numpy()
x_test = test_data.data.numpy().reshape(-1, 784)
y_test = test_data.targets.numpy() 

x_train = x_train.reshape(-1, 1, 28, 28)
x_test = x_test.reshape(-1, 1, 28, 28)

print(x_train.shape, y_train.shape)
print(x_test.shape, y_test.shape)

```